### PR TITLE
Fix UTF-8 in urls and mentions

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -120,10 +120,16 @@ nonpipe = ^'|';
 nonpipebracket = nonpipe & nonbracket;
 noncurly = ^'}';
 
-mention = '@' graph+ >mark_a1 %mark_a2;
+utf8graph = (0x00..0x7F) & graph
+          | 0xC2..0xDF 0x80..0xBF
+          | 0xE0..0xEF 0x80..0xBF 0x80..0xBF
+          | 0xF0..0xF4 0x80..0xBF 0x80..0xBF 0x80..0xBF;
 
-url = 'http' 's'? '://' graph+;
-internal_url = '/' graph+;
+
+mention = '@' utf8graph+ >mark_a1 %mark_a2;
+
+url = 'http' 's'? '://' utf8graph+;
+internal_url = '/' utf8graph+;
 basic_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':' (url | internal_url) >mark_b1 %mark_b2;
 bracketed_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':[' (url | internal_url) >mark_b1 %mark_b2 :>> ']';
 

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -256,4 +256,16 @@ class DTextTest < Minitest::Test
   def test_old_asterisks
     assert_parse("<p>hello *world* neutral</p>", "hello *world* neutral")
   end
+
+  def test_utf8_mentions
+    assert_parse('<p><a rel="nofollow" href="/users?name=葉月">@葉月</a></p>', "@葉月")
+    assert_parse('<p>Hello <a rel="nofollow" href="/users?name=葉月">@葉月</a> and <a rel="nofollow" href="/users?name=Alice">@Alice</a></p>', "Hello @葉月 and @Alice")
+    assert_parse('<p>Should not parse 葉月@葉月</p>', "Should not parse 葉月@葉月")
+  end
+
+  def test_utf8_links
+    assert_parse('<p><a href="/posts?tags=approver:葉月">7893</a></p>', '"7893":/posts?tags=approver:葉月')
+    assert_parse('<p><a href="/posts?tags=approver:葉月">7893</a></p>', '"7893":[/posts?tags=approver:葉月]')
+    assert_parse('<p><a href="http://danbooru.donmai.us/posts?tags=approver:葉月">http://danbooru.donmai.us/posts?tags=approver:葉月</a></p>', 'http://danbooru.donmai.us/posts?tags=approver:葉月')
+  end
 end


### PR DESCRIPTION
This allows parser to handle UTF-8 characters where necessary by defining `utf8graph` machine. Single-byte control characters are filtered by intersecting with `graph`; multibyte non-printable characters are NOT filtered out, because I was unable to find a proper listing. It can be done later if necessary at all.

See r888888888/danbooru#2683 for details.