### PR TITLE
Fix [spoilers] tags

### DIFF
--- a/ext/dtext/dtext.c
+++ b/ext/dtext/dtext.c
@@ -72,7 +72,7 @@ static const int BLOCK_H5 = 27;
 static const int BLOCK_H6 = 28;
 
 
-#line 1053 "ext/dtext/dtext.rl"
+#line 1056 "ext/dtext/dtext.rl"
 
 
 
@@ -110,15 +110,16 @@ static const short _dtext_to_state_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 60, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 60, 0, 
+	0, 0, 60, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 60, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 60, 0, 60, 0, 60, 
-	0, 60, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 60, 
+	0, 60, 0, 60, 0, 60, 0, 0, 
+	0, 0, 0
 };
 
 static const short _dtext_from_state_actions[] = {
@@ -154,30 +155,31 @@ static const short _dtext_from_state_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 61, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 61, 0, 
+	0, 0, 61, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 61, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 61, 0, 61, 0, 61, 
-	0, 61, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 61, 
+	0, 61, 0, 61, 0, 61, 0, 0, 
+	0, 0, 0
 };
 
-static const int dtext_start = 262;
-static const int dtext_first_final = 262;
+static const int dtext_start = 266;
+static const int dtext_first_final = 266;
 static const int dtext_error = -1;
 
-static const int dtext_en_inline = 278;
-static const int dtext_en_code = 315;
-static const int dtext_en_nodtext = 317;
-static const int dtext_en_table = 319;
-static const int dtext_en_list = 321;
-static const int dtext_en_main = 262;
+static const int dtext_en_inline = 282;
+static const int dtext_en_code = 319;
+static const int dtext_en_nodtext = 321;
+static const int dtext_en_table = 323;
+static const int dtext_en_list = 325;
+static const int dtext_en_main = 266;
 
 
-#line 1056 "ext/dtext/dtext.rl"
+#line 1059 "ext/dtext/dtext.rl"
 
 static inline void underscore_string(char * str, size_t len) {
   for (size_t i=0; i<len; ++i) {
@@ -507,7 +509,7 @@ static StateMachine * parse_helper(const char * src, size_t len, bool f_strip, b
   sm->f_mentions = f_mentions;
 
   
-#line 511 "ext/dtext/dtext.c"
+#line 513 "ext/dtext/dtext.c"
 	{
 	 sm->cs = dtext_start;
 	( sm->top) = 0;
@@ -516,9 +518,9 @@ static StateMachine * parse_helper(const char * src, size_t len, bool f_strip, b
 	( sm->act) = 0;
 	}
 
-#line 1385 "ext/dtext/dtext.rl"
+#line 1388 "ext/dtext/dtext.rl"
   
-#line 522 "ext/dtext/dtext.c"
+#line 524 "ext/dtext/dtext.c"
 	{
 	if ( ( sm->p) == ( sm->pe) )
 		goto _test_eof;
@@ -528,42 +530,42 @@ _resume:
 #line 1 "NONE"
 	{( sm->ts) = ( sm->p);}
 	break;
-#line 532 "ext/dtext/dtext.c"
+#line 534 "ext/dtext/dtext.c"
 	}
 
 	switch (  sm->cs ) {
-case 262:
+case 266:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr315;
-		case 10: goto tr316;
-		case 13: goto tr317;
-		case 42: goto tr318;
-		case 72: goto tr319;
-		case 91: goto tr320;
-		case 104: goto tr319;
+		case 0: goto tr319;
+		case 10: goto tr320;
+		case 13: goto tr321;
+		case 42: goto tr322;
+		case 72: goto tr323;
+		case 91: goto tr324;
+		case 104: goto tr323;
 	}
-	goto tr314;
-case 263:
+	goto tr318;
+case 267:
 	switch( (*( sm->p)) ) {
 		case 10: goto tr1;
-		case 13: goto tr321;
+		case 13: goto tr325;
 	}
 	goto tr0;
 case 0:
 	if ( (*( sm->p)) == 10 )
 		goto tr1;
 	goto tr0;
-case 264:
+case 268:
 	if ( (*( sm->p)) == 10 )
-		goto tr316;
-	goto tr322;
-case 265:
+		goto tr320;
+	goto tr326;
+case 269:
 	switch( (*( sm->p)) ) {
 		case 9: goto tr5;
 		case 32: goto tr5;
 		case 42: goto tr6;
 	}
-	goto tr322;
+	goto tr326;
 case 1:
 	switch( (*( sm->p)) ) {
 		case 0: goto tr2;
@@ -573,19 +575,19 @@ case 1:
 		case 32: goto tr4;
 	}
 	goto tr3;
-case 266:
+case 270:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr323;
-		case 10: goto tr323;
-		case 13: goto tr323;
+		case 0: goto tr327;
+		case 10: goto tr327;
+		case 13: goto tr327;
 	}
-	goto tr324;
-case 267:
+	goto tr328;
+case 271:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr323;
+		case 0: goto tr327;
 		case 9: goto tr4;
-		case 10: goto tr323;
-		case 13: goto tr323;
+		case 10: goto tr327;
+		case 13: goto tr327;
 		case 32: goto tr4;
 	}
 	goto tr3;
@@ -596,10 +598,10 @@ case 2:
 		case 42: goto tr6;
 	}
 	goto tr2;
-case 268:
+case 272:
 	if ( 49 <= (*( sm->p)) && (*( sm->p)) <= 54 )
-		goto tr325;
-	goto tr322;
+		goto tr329;
+	goto tr326;
 case 3:
 	switch( (*( sm->p)) ) {
 		case 35: goto tr7;
@@ -623,35 +625,35 @@ case 5:
 	if ( 35 <= (*( sm->p)) && (*( sm->p)) <= 126 )
 		goto tr10;
 	goto tr2;
-case 269:
+case 273:
 	switch( (*( sm->p)) ) {
-		case 9: goto tr327;
-		case 32: goto tr327;
+		case 9: goto tr331;
+		case 32: goto tr331;
+	}
+	goto tr330;
+case 274:
+	switch( (*( sm->p)) ) {
+		case 9: goto tr333;
+		case 32: goto tr333;
+	}
+	goto tr332;
+case 275:
+	switch( (*( sm->p)) ) {
+		case 47: goto tr334;
+		case 67: goto tr335;
+		case 69: goto tr336;
+		case 78: goto tr337;
+		case 81: goto tr338;
+		case 83: goto tr339;
+		case 84: goto tr340;
+		case 99: goto tr335;
+		case 101: goto tr336;
+		case 110: goto tr337;
+		case 113: goto tr338;
+		case 115: goto tr339;
+		case 116: goto tr340;
 	}
 	goto tr326;
-case 270:
-	switch( (*( sm->p)) ) {
-		case 9: goto tr329;
-		case 32: goto tr329;
-	}
-	goto tr328;
-case 271:
-	switch( (*( sm->p)) ) {
-		case 47: goto tr330;
-		case 67: goto tr331;
-		case 69: goto tr332;
-		case 78: goto tr333;
-		case 81: goto tr334;
-		case 83: goto tr335;
-		case 84: goto tr336;
-		case 99: goto tr331;
-		case 101: goto tr332;
-		case 110: goto tr333;
-		case 113: goto tr334;
-		case 115: goto tr335;
-		case 116: goto tr336;
-	}
-	goto tr322;
 case 6:
 	switch( (*( sm->p)) ) {
 		case 83: goto tr12;
@@ -695,1765 +697,1793 @@ case 12:
 	}
 	goto tr2;
 case 13:
-	if ( (*( sm->p)) == 93 )
-		goto tr19;
+	switch( (*( sm->p)) ) {
+		case 83: goto tr19;
+		case 93: goto tr20;
+		case 115: goto tr19;
+	}
 	goto tr2;
 case 14:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr20;
-		case 111: goto tr20;
-	}
+	if ( (*( sm->p)) == 93 )
+		goto tr20;
 	goto tr2;
 case 15:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr21;
-		case 100: goto tr21;
+		case 79: goto tr21;
+		case 111: goto tr21;
 	}
 	goto tr2;
 case 16:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr22;
-		case 101: goto tr22;
+		case 68: goto tr22;
+		case 100: goto tr22;
 	}
 	goto tr2;
 case 17:
-	if ( (*( sm->p)) == 93 )
-		goto tr23;
-	goto tr2;
-case 272:
-	if ( (*( sm->p)) == 32 )
-		goto tr23;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr23;
-	goto tr337;
-case 18:
 	switch( (*( sm->p)) ) {
-		case 88: goto tr24;
-		case 120: goto tr24;
+		case 69: goto tr23;
+		case 101: goto tr23;
 	}
 	goto tr2;
+case 18:
+	if ( (*( sm->p)) == 93 )
+		goto tr24;
+	goto tr2;
+case 276:
+	if ( (*( sm->p)) == 32 )
+		goto tr24;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr24;
+	goto tr341;
 case 19:
 	switch( (*( sm->p)) ) {
-		case 80: goto tr25;
-		case 112: goto tr25;
+		case 88: goto tr25;
+		case 120: goto tr25;
 	}
 	goto tr2;
 case 20:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr26;
-		case 97: goto tr26;
+		case 80: goto tr26;
+		case 112: goto tr26;
 	}
 	goto tr2;
 case 21:
 	switch( (*( sm->p)) ) {
-		case 78: goto tr27;
-		case 110: goto tr27;
+		case 65: goto tr27;
+		case 97: goto tr27;
 	}
 	goto tr2;
 case 22:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr28;
-		case 100: goto tr28;
+		case 78: goto tr28;
+		case 110: goto tr28;
 	}
 	goto tr2;
 case 23:
 	switch( (*( sm->p)) ) {
-		case 61: goto tr29;
-		case 93: goto tr30;
+		case 68: goto tr29;
+		case 100: goto tr29;
 	}
 	goto tr2;
 case 24:
-	if ( (*( sm->p)) == 93 )
-		goto tr2;
-	goto tr31;
-case 25:
-	if ( (*( sm->p)) == 93 )
-		goto tr33;
-	goto tr32;
-case 273:
-	if ( (*( sm->p)) == 32 )
-		goto tr339;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr339;
-	goto tr338;
-case 274:
-	if ( (*( sm->p)) == 32 )
-		goto tr30;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr30;
-	goto tr340;
-case 26:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr34;
-		case 111: goto tr34;
+		case 61: goto tr30;
+		case 93: goto tr31;
 	}
 	goto tr2;
+case 25:
+	if ( (*( sm->p)) == 93 )
+		goto tr2;
+	goto tr32;
+case 26:
+	if ( (*( sm->p)) == 93 )
+		goto tr34;
+	goto tr33;
+case 277:
+	if ( (*( sm->p)) == 32 )
+		goto tr343;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr343;
+	goto tr342;
+case 278:
+	if ( (*( sm->p)) == 32 )
+		goto tr31;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr31;
+	goto tr344;
 case 27:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr35;
-		case 100: goto tr35;
+		case 79: goto tr35;
+		case 111: goto tr35;
 	}
 	goto tr2;
 case 28:
 	switch( (*( sm->p)) ) {
-		case 84: goto tr36;
-		case 116: goto tr36;
+		case 68: goto tr36;
+		case 100: goto tr36;
 	}
 	goto tr2;
 case 29:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr37;
-		case 101: goto tr37;
+		case 84: goto tr37;
+		case 116: goto tr37;
 	}
 	goto tr2;
 case 30:
 	switch( (*( sm->p)) ) {
-		case 88: goto tr38;
-		case 120: goto tr38;
+		case 69: goto tr38;
+		case 101: goto tr38;
 	}
 	goto tr2;
 case 31:
 	switch( (*( sm->p)) ) {
-		case 84: goto tr39;
-		case 116: goto tr39;
+		case 88: goto tr39;
+		case 120: goto tr39;
 	}
 	goto tr2;
 case 32:
-	if ( (*( sm->p)) == 93 )
-		goto tr40;
-	goto tr2;
-case 275:
-	if ( (*( sm->p)) == 32 )
-		goto tr40;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr40;
-	goto tr341;
-case 33:
 	switch( (*( sm->p)) ) {
-		case 85: goto tr41;
-		case 117: goto tr41;
+		case 84: goto tr40;
+		case 116: goto tr40;
 	}
 	goto tr2;
+case 33:
+	if ( (*( sm->p)) == 93 )
+		goto tr41;
+	goto tr2;
+case 279:
+	if ( (*( sm->p)) == 32 )
+		goto tr41;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr41;
+	goto tr345;
 case 34:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr42;
-		case 111: goto tr42;
+		case 85: goto tr42;
+		case 117: goto tr42;
 	}
 	goto tr2;
 case 35:
 	switch( (*( sm->p)) ) {
-		case 84: goto tr43;
-		case 116: goto tr43;
+		case 79: goto tr43;
+		case 111: goto tr43;
 	}
 	goto tr2;
 case 36:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr44;
-		case 101: goto tr44;
+		case 84: goto tr44;
+		case 116: goto tr44;
 	}
 	goto tr2;
 case 37:
-	if ( (*( sm->p)) == 93 )
-		goto tr45;
-	goto tr2;
-case 276:
-	if ( (*( sm->p)) == 32 )
-		goto tr45;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr45;
-	goto tr342;
-case 38:
 	switch( (*( sm->p)) ) {
-		case 80: goto tr46;
-		case 112: goto tr46;
+		case 69: goto tr45;
+		case 101: goto tr45;
 	}
 	goto tr2;
+case 38:
+	if ( (*( sm->p)) == 93 )
+		goto tr46;
+	goto tr2;
+case 280:
+	if ( (*( sm->p)) == 32 )
+		goto tr46;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr46;
+	goto tr346;
 case 39:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr47;
-		case 111: goto tr47;
+		case 80: goto tr47;
+		case 112: goto tr47;
 	}
 	goto tr2;
 case 40:
 	switch( (*( sm->p)) ) {
-		case 73: goto tr48;
-		case 105: goto tr48;
+		case 79: goto tr48;
+		case 111: goto tr48;
 	}
 	goto tr2;
 case 41:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr49;
-		case 108: goto tr49;
+		case 73: goto tr49;
+		case 105: goto tr49;
 	}
 	goto tr2;
 case 42:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr50;
-		case 101: goto tr50;
+		case 76: goto tr50;
+		case 108: goto tr50;
 	}
 	goto tr2;
 case 43:
 	switch( (*( sm->p)) ) {
-		case 82: goto tr51;
-		case 114: goto tr51;
+		case 69: goto tr51;
+		case 101: goto tr51;
 	}
 	goto tr2;
 case 44:
-	if ( (*( sm->p)) == 93 )
-		goto tr52;
+	switch( (*( sm->p)) ) {
+		case 82: goto tr52;
+		case 114: goto tr52;
+	}
 	goto tr2;
-case 277:
-	if ( (*( sm->p)) == 32 )
-		goto tr52;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr52;
-	goto tr343;
 case 45:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr53;
-		case 78: goto tr54;
-		case 97: goto tr53;
-		case 110: goto tr54;
+		case 83: goto tr53;
+		case 93: goto tr54;
+		case 115: goto tr53;
 	}
 	goto tr2;
 case 46:
-	switch( (*( sm->p)) ) {
-		case 66: goto tr55;
-		case 98: goto tr55;
-	}
+	if ( (*( sm->p)) == 93 )
+		goto tr54;
 	goto tr2;
+case 281:
+	if ( (*( sm->p)) == 32 )
+		goto tr54;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr54;
+	goto tr347;
 case 47:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr56;
-		case 108: goto tr56;
+		case 65: goto tr55;
+		case 78: goto tr56;
+		case 97: goto tr55;
+		case 110: goto tr56;
 	}
 	goto tr2;
 case 48:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr57;
-		case 101: goto tr57;
+		case 66: goto tr57;
+		case 98: goto tr57;
 	}
 	goto tr2;
 case 49:
-	if ( (*( sm->p)) == 93 )
-		goto tr58;
+	switch( (*( sm->p)) ) {
+		case 76: goto tr58;
+		case 108: goto tr58;
+	}
 	goto tr2;
 case 50:
-	if ( (*( sm->p)) == 93 )
-		goto tr59;
+	switch( (*( sm->p)) ) {
+		case 69: goto tr59;
+		case 101: goto tr59;
+	}
 	goto tr2;
-case 278:
-	switch( (*( sm->p)) ) {
-		case 0: goto tr345;
-		case 10: goto tr346;
-		case 13: goto tr347;
-		case 34: goto tr348;
-		case 64: goto tr349;
-		case 65: goto tr350;
-		case 67: goto tr351;
-		case 70: goto tr352;
-		case 72: goto tr353;
-		case 73: goto tr354;
-		case 80: goto tr355;
-		case 84: goto tr356;
-		case 85: goto tr357;
-		case 91: goto tr358;
-		case 97: goto tr350;
-		case 99: goto tr351;
-		case 102: goto tr352;
-		case 104: goto tr359;
-		case 105: goto tr354;
-		case 112: goto tr355;
-		case 116: goto tr356;
-		case 117: goto tr357;
-		case 123: goto tr360;
-	}
-	goto tr344;
-case 279:
-	switch( (*( sm->p)) ) {
-		case 10: goto tr61;
-		case 13: goto tr362;
-		case 42: goto tr363;
-	}
-	goto tr361;
-case 280:
-	switch( (*( sm->p)) ) {
-		case 10: goto tr61;
-		case 13: goto tr362;
-	}
-	goto tr364;
 case 51:
-	if ( (*( sm->p)) == 10 )
-		goto tr61;
-	goto tr60;
+	if ( (*( sm->p)) == 93 )
+		goto tr60;
+	goto tr2;
 case 52:
-	switch( (*( sm->p)) ) {
-		case 9: goto tr63;
-		case 32: goto tr63;
-		case 42: goto tr64;
-	}
-	goto tr62;
-case 53:
-	switch( (*( sm->p)) ) {
-		case 0: goto tr62;
-		case 9: goto tr66;
-		case 10: goto tr62;
-		case 13: goto tr62;
-		case 32: goto tr66;
-	}
-	goto tr65;
-case 281:
-	switch( (*( sm->p)) ) {
-		case 0: goto tr365;
-		case 10: goto tr365;
-		case 13: goto tr365;
-	}
-	goto tr366;
+	if ( (*( sm->p)) == 93 )
+		goto tr61;
+	goto tr2;
 case 282:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr365;
-		case 9: goto tr66;
-		case 10: goto tr365;
-		case 13: goto tr365;
-		case 32: goto tr66;
+		case 0: goto tr349;
+		case 10: goto tr350;
+		case 13: goto tr351;
+		case 34: goto tr352;
+		case 64: goto tr353;
+		case 65: goto tr354;
+		case 67: goto tr355;
+		case 70: goto tr356;
+		case 72: goto tr357;
+		case 73: goto tr358;
+		case 80: goto tr359;
+		case 84: goto tr360;
+		case 85: goto tr361;
+		case 91: goto tr362;
+		case 97: goto tr354;
+		case 99: goto tr355;
+		case 102: goto tr356;
+		case 104: goto tr363;
+		case 105: goto tr358;
+		case 112: goto tr359;
+		case 116: goto tr360;
+		case 117: goto tr361;
+		case 123: goto tr364;
 	}
-	goto tr65;
+	goto tr348;
 case 283:
-	if ( (*( sm->p)) == 10 )
-		goto tr346;
-	goto tr367;
-case 284:
-	if ( (*( sm->p)) == 34 )
-		goto tr368;
-	goto tr369;
-case 54:
-	if ( (*( sm->p)) == 34 )
-		goto tr69;
-	goto tr68;
-case 55:
-	if ( (*( sm->p)) == 58 )
-		goto tr70;
-	goto tr67;
-case 56:
 	switch( (*( sm->p)) ) {
-		case 47: goto tr71;
-		case 91: goto tr72;
-		case 104: goto tr73;
+		case 10: goto tr63;
+		case 13: goto tr366;
+		case 42: goto tr367;
+	}
+	goto tr365;
+case 284:
+	switch( (*( sm->p)) ) {
+		case 10: goto tr63;
+		case 13: goto tr366;
+	}
+	goto tr368;
+case 53:
+	if ( (*( sm->p)) == 10 )
+		goto tr63;
+	goto tr62;
+case 54:
+	switch( (*( sm->p)) ) {
+		case 9: goto tr65;
+		case 32: goto tr65;
+		case 42: goto tr66;
+	}
+	goto tr64;
+case 55:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr64;
+		case 9: goto tr68;
+		case 10: goto tr64;
+		case 13: goto tr64;
+		case 32: goto tr68;
 	}
 	goto tr67;
-case 57:
-	if ( (*( sm->p)) < -32 ) {
-		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr74;
-	} else if ( (*( sm->p)) > -17 ) {
-		if ( (*( sm->p)) > -12 ) {
-			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr77;
-		} else if ( (*( sm->p)) >= -16 )
-			goto tr76;
-	} else
-		goto tr75;
-	goto tr67;
-case 58:
-	if ( (*( sm->p)) <= -65 )
-		goto tr77;
-	goto tr60;
 case 285:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr369;
+		case 10: goto tr369;
+		case 13: goto tr369;
+	}
+	goto tr370;
+case 286:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr369;
+		case 9: goto tr68;
+		case 10: goto tr369;
+		case 13: goto tr369;
+		case 32: goto tr68;
+	}
+	goto tr67;
+case 287:
+	if ( (*( sm->p)) == 10 )
+		goto tr350;
+	goto tr371;
+case 288:
+	if ( (*( sm->p)) == 34 )
+		goto tr372;
+	goto tr373;
+case 56:
+	if ( (*( sm->p)) == 34 )
+		goto tr71;
+	goto tr70;
+case 57:
+	if ( (*( sm->p)) == 58 )
+		goto tr72;
+	goto tr69;
+case 58:
+	switch( (*( sm->p)) ) {
+		case 47: goto tr73;
+		case 91: goto tr74;
+		case 104: goto tr75;
+	}
+	goto tr69;
+case 59:
 	if ( (*( sm->p)) < -32 ) {
 		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr74;
+			goto tr76;
 	} else if ( (*( sm->p)) > -17 ) {
 		if ( (*( sm->p)) > -12 ) {
 			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr77;
+				goto tr79;
 		} else if ( (*( sm->p)) >= -16 )
-			goto tr76;
+			goto tr78;
 	} else
-		goto tr75;
-	goto tr370;
-case 59:
-	if ( (*( sm->p)) <= -65 )
-		goto tr74;
-	goto tr60;
+		goto tr77;
+	goto tr69;
 case 60:
 	if ( (*( sm->p)) <= -65 )
-		goto tr75;
-	goto tr60;
+		goto tr79;
+	goto tr62;
+case 289:
+	if ( (*( sm->p)) < -32 ) {
+		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
+			goto tr76;
+	} else if ( (*( sm->p)) > -17 ) {
+		if ( (*( sm->p)) > -12 ) {
+			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+				goto tr79;
+		} else if ( (*( sm->p)) >= -16 )
+			goto tr78;
+	} else
+		goto tr77;
+	goto tr374;
 case 61:
-	switch( (*( sm->p)) ) {
-		case 47: goto tr78;
-		case 104: goto tr79;
-	}
-	goto tr67;
-case 62:
-	if ( (*( sm->p)) < -32 ) {
-		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr80;
-	} else if ( (*( sm->p)) > -17 ) {
-		if ( (*( sm->p)) > -12 ) {
-			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr83;
-		} else if ( (*( sm->p)) >= -16 )
-			goto tr82;
-	} else
-		goto tr81;
-	goto tr67;
-case 63:
 	if ( (*( sm->p)) <= -65 )
-		goto tr83;
-	goto tr67;
+		goto tr76;
+	goto tr62;
+case 62:
+	if ( (*( sm->p)) <= -65 )
+		goto tr77;
+	goto tr62;
+case 63:
+	switch( (*( sm->p)) ) {
+		case 47: goto tr80;
+		case 104: goto tr81;
+	}
+	goto tr69;
 case 64:
-	if ( (*( sm->p)) == 93 )
-		goto tr84;
 	if ( (*( sm->p)) < -32 ) {
 		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr80;
+			goto tr82;
 	} else if ( (*( sm->p)) > -17 ) {
 		if ( (*( sm->p)) > -12 ) {
 			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr83;
+				goto tr85;
 		} else if ( (*( sm->p)) >= -16 )
-			goto tr82;
+			goto tr84;
 	} else
-		goto tr81;
-	goto tr67;
+		goto tr83;
+	goto tr69;
 case 65:
 	if ( (*( sm->p)) <= -65 )
-		goto tr80;
-	goto tr67;
-case 66:
-	if ( (*( sm->p)) <= -65 )
-		goto tr81;
-	goto tr67;
-case 67:
-	if ( (*( sm->p)) == 116 )
 		goto tr85;
-	goto tr67;
-case 68:
-	if ( (*( sm->p)) == 116 )
+	goto tr69;
+case 66:
+	if ( (*( sm->p)) == 93 )
 		goto tr86;
-	goto tr67;
+	if ( (*( sm->p)) < -32 ) {
+		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
+			goto tr82;
+	} else if ( (*( sm->p)) > -17 ) {
+		if ( (*( sm->p)) > -12 ) {
+			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+				goto tr85;
+		} else if ( (*( sm->p)) >= -16 )
+			goto tr84;
+	} else
+		goto tr83;
+	goto tr69;
+case 67:
+	if ( (*( sm->p)) <= -65 )
+		goto tr82;
+	goto tr69;
+case 68:
+	if ( (*( sm->p)) <= -65 )
+		goto tr83;
+	goto tr69;
 case 69:
-	if ( (*( sm->p)) == 112 )
+	if ( (*( sm->p)) == 116 )
 		goto tr87;
-	goto tr67;
+	goto tr69;
 case 70:
-	switch( (*( sm->p)) ) {
-		case 58: goto tr88;
-		case 115: goto tr89;
-	}
-	goto tr67;
-case 71:
-	if ( (*( sm->p)) == 47 )
-		goto tr90;
-	goto tr67;
-case 72:
-	if ( (*( sm->p)) == 47 )
-		goto tr91;
-	goto tr67;
-case 73:
-	if ( (*( sm->p)) == 58 )
+	if ( (*( sm->p)) == 116 )
 		goto tr88;
-	goto tr67;
-case 74:
-	if ( (*( sm->p)) == 116 )
-		goto tr92;
-	goto tr67;
-case 75:
-	if ( (*( sm->p)) == 116 )
-		goto tr93;
-	goto tr67;
-case 76:
+	goto tr69;
+case 71:
 	if ( (*( sm->p)) == 112 )
-		goto tr94;
-	goto tr67;
-case 77:
+		goto tr89;
+	goto tr69;
+case 72:
 	switch( (*( sm->p)) ) {
-		case 58: goto tr95;
-		case 115: goto tr96;
+		case 58: goto tr90;
+		case 115: goto tr91;
 	}
-	goto tr67;
-case 78:
+	goto tr69;
+case 73:
 	if ( (*( sm->p)) == 47 )
-		goto tr97;
-	goto tr67;
-case 79:
+		goto tr92;
+	goto tr69;
+case 74:
 	if ( (*( sm->p)) == 47 )
-		goto tr98;
-	goto tr67;
-case 80:
+		goto tr93;
+	goto tr69;
+case 75:
 	if ( (*( sm->p)) == 58 )
+		goto tr90;
+	goto tr69;
+case 76:
+	if ( (*( sm->p)) == 116 )
+		goto tr94;
+	goto tr69;
+case 77:
+	if ( (*( sm->p)) == 116 )
 		goto tr95;
-	goto tr67;
-case 286:
-	if ( (*( sm->p)) < -32 ) {
-		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr371;
-	} else if ( (*( sm->p)) > -17 ) {
-		if ( (*( sm->p)) > -12 ) {
-			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr374;
-		} else if ( (*( sm->p)) >= -16 )
-			goto tr373;
-	} else
-		goto tr372;
-	goto tr368;
-case 81:
-	if ( (*( sm->p)) <= -65 )
+	goto tr69;
+case 78:
+	if ( (*( sm->p)) == 112 )
+		goto tr96;
+	goto tr69;
+case 79:
+	switch( (*( sm->p)) ) {
+		case 58: goto tr97;
+		case 115: goto tr98;
+	}
+	goto tr69;
+case 80:
+	if ( (*( sm->p)) == 47 )
 		goto tr99;
-	goto tr60;
-case 287:
+	goto tr69;
+case 81:
+	if ( (*( sm->p)) == 47 )
+		goto tr100;
+	goto tr69;
+case 82:
+	if ( (*( sm->p)) == 58 )
+		goto tr97;
+	goto tr69;
+case 290:
 	if ( (*( sm->p)) < -32 ) {
 		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr100;
+			goto tr375;
 	} else if ( (*( sm->p)) > -17 ) {
 		if ( (*( sm->p)) > -12 ) {
 			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr99;
+				goto tr378;
 		} else if ( (*( sm->p)) >= -16 )
-			goto tr376;
+			goto tr377;
 	} else
-		goto tr101;
-	goto tr375;
-case 82:
-	if ( (*( sm->p)) <= -65 )
-		goto tr100;
-	goto tr60;
+		goto tr376;
+	goto tr372;
 case 83:
 	if ( (*( sm->p)) <= -65 )
 		goto tr101;
-	goto tr60;
-case 288:
-	if ( (*( sm->p)) == 64 )
-		goto tr378;
+	goto tr62;
+case 291:
 	if ( (*( sm->p)) < -32 ) {
 		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr100;
+			goto tr102;
 	} else if ( (*( sm->p)) > -17 ) {
 		if ( (*( sm->p)) > -12 ) {
 			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr99;
+				goto tr101;
 		} else if ( (*( sm->p)) >= -16 )
-			goto tr376;
+			goto tr380;
 	} else
-		goto tr101;
-	goto tr377;
-case 289:
-	switch( (*( sm->p)) ) {
-		case 82: goto tr379;
-		case 114: goto tr379;
-	}
-	goto tr368;
+		goto tr103;
+	goto tr379;
 case 84:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr102;
-		case 116: goto tr102;
-	}
-	goto tr67;
+	if ( (*( sm->p)) <= -65 )
+		goto tr102;
+	goto tr62;
 case 85:
-	switch( (*( sm->p)) ) {
-		case 73: goto tr103;
-		case 105: goto tr103;
-	}
-	goto tr67;
-case 86:
-	switch( (*( sm->p)) ) {
-		case 83: goto tr104;
-		case 115: goto tr104;
-	}
-	goto tr67;
-case 87:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr105;
-		case 116: goto tr105;
-	}
-	goto tr67;
-case 88:
-	if ( (*( sm->p)) == 32 )
-		goto tr106;
-	goto tr67;
-case 89:
-	if ( (*( sm->p)) == 35 )
-		goto tr107;
-	goto tr67;
-case 90:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr108;
-	goto tr67;
-case 290:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr381;
-	goto tr380;
-case 291:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr382;
-		case 111: goto tr382;
-	}
-	goto tr368;
-case 91:
-	switch( (*( sm->p)) ) {
-		case 77: goto tr109;
-		case 109: goto tr109;
-	}
-	goto tr67;
-case 92:
-	switch( (*( sm->p)) ) {
-		case 77: goto tr110;
-		case 109: goto tr110;
-	}
-	goto tr67;
-case 93:
-	switch( (*( sm->p)) ) {
-		case 69: goto tr111;
-		case 101: goto tr111;
-	}
-	goto tr67;
-case 94:
-	switch( (*( sm->p)) ) {
-		case 78: goto tr112;
-		case 110: goto tr112;
-	}
-	goto tr67;
-case 95:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr113;
-		case 116: goto tr113;
-	}
-	goto tr67;
-case 96:
-	if ( (*( sm->p)) == 32 )
-		goto tr114;
-	goto tr67;
-case 97:
-	if ( (*( sm->p)) == 35 )
-		goto tr115;
-	goto tr67;
-case 98:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr116;
-	goto tr67;
+	if ( (*( sm->p)) <= -65 )
+		goto tr103;
+	goto tr62;
 case 292:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr384;
-	goto tr383;
+	if ( (*( sm->p)) == 64 )
+		goto tr382;
+	if ( (*( sm->p)) < -32 ) {
+		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
+			goto tr102;
+	} else if ( (*( sm->p)) > -17 ) {
+		if ( (*( sm->p)) > -12 ) {
+			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+				goto tr101;
+		} else if ( (*( sm->p)) >= -16 )
+			goto tr380;
+	} else
+		goto tr103;
+	goto tr381;
 case 293:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr385;
-		case 111: goto tr385;
+		case 82: goto tr383;
+		case 114: goto tr383;
 	}
-	goto tr368;
-case 99:
+	goto tr372;
+case 86:
 	switch( (*( sm->p)) ) {
-		case 82: goto tr117;
-		case 114: goto tr117;
+		case 84: goto tr104;
+		case 116: goto tr104;
 	}
-	goto tr67;
-case 100:
+	goto tr69;
+case 87:
 	switch( (*( sm->p)) ) {
-		case 85: goto tr118;
-		case 117: goto tr118;
+		case 73: goto tr105;
+		case 105: goto tr105;
 	}
-	goto tr67;
-case 101:
+	goto tr69;
+case 88:
 	switch( (*( sm->p)) ) {
-		case 77: goto tr119;
-		case 109: goto tr119;
+		case 83: goto tr106;
+		case 115: goto tr106;
 	}
-	goto tr67;
-case 102:
+	goto tr69;
+case 89:
+	switch( (*( sm->p)) ) {
+		case 84: goto tr107;
+		case 116: goto tr107;
+	}
+	goto tr69;
+case 90:
 	if ( (*( sm->p)) == 32 )
-		goto tr120;
-	goto tr67;
-case 103:
+		goto tr108;
+	goto tr69;
+case 91:
 	if ( (*( sm->p)) == 35 )
-		goto tr121;
-	goto tr67;
-case 104:
+		goto tr109;
+	goto tr69;
+case 92:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr122;
-	goto tr67;
+		goto tr110;
+	goto tr69;
 case 294:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr387;
-	goto tr386;
+		goto tr385;
+	goto tr384;
 case 295:
-	if ( 49 <= (*( sm->p)) && (*( sm->p)) <= 54 )
-		goto tr388;
-	goto tr368;
-case 105:
 	switch( (*( sm->p)) ) {
-		case 35: goto tr123;
-		case 46: goto tr124;
+		case 79: goto tr386;
+		case 111: goto tr386;
 	}
-	goto tr67;
-case 106:
-	if ( (*( sm->p)) == 33 )
-		goto tr125;
-	if ( (*( sm->p)) > 45 ) {
-		if ( 47 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-			goto tr125;
-	} else if ( (*( sm->p)) >= 35 )
-		goto tr125;
-	goto tr67;
-case 107:
+	goto tr372;
+case 93:
 	switch( (*( sm->p)) ) {
-		case 33: goto tr126;
-		case 46: goto tr127;
+		case 77: goto tr111;
+		case 109: goto tr111;
 	}
-	if ( 35 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-		goto tr126;
-	goto tr67;
+	goto tr69;
+case 94:
+	switch( (*( sm->p)) ) {
+		case 77: goto tr112;
+		case 109: goto tr112;
+	}
+	goto tr69;
+case 95:
+	switch( (*( sm->p)) ) {
+		case 69: goto tr113;
+		case 101: goto tr113;
+	}
+	goto tr69;
+case 96:
+	switch( (*( sm->p)) ) {
+		case 78: goto tr114;
+		case 110: goto tr114;
+	}
+	goto tr69;
+case 97:
+	switch( (*( sm->p)) ) {
+		case 84: goto tr115;
+		case 116: goto tr115;
+	}
+	goto tr69;
+case 98:
+	if ( (*( sm->p)) == 32 )
+		goto tr116;
+	goto tr69;
+case 99:
+	if ( (*( sm->p)) == 35 )
+		goto tr117;
+	goto tr69;
+case 100:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr118;
+	goto tr69;
 case 296:
-	switch( (*( sm->p)) ) {
-		case 9: goto tr390;
-		case 32: goto tr390;
-	}
-	goto tr389;
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr388;
+	goto tr387;
 case 297:
 	switch( (*( sm->p)) ) {
-		case 9: goto tr392;
-		case 32: goto tr392;
+		case 79: goto tr389;
+		case 111: goto tr389;
 	}
-	goto tr391;
+	goto tr372;
+case 101:
+	switch( (*( sm->p)) ) {
+		case 82: goto tr119;
+		case 114: goto tr119;
+	}
+	goto tr69;
+case 102:
+	switch( (*( sm->p)) ) {
+		case 85: goto tr120;
+		case 117: goto tr120;
+	}
+	goto tr69;
+case 103:
+	switch( (*( sm->p)) ) {
+		case 77: goto tr121;
+		case 109: goto tr121;
+	}
+	goto tr69;
+case 104:
+	if ( (*( sm->p)) == 32 )
+		goto tr122;
+	goto tr69;
+case 105:
+	if ( (*( sm->p)) == 35 )
+		goto tr123;
+	goto tr69;
+case 106:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr124;
+	goto tr69;
 case 298:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr391;
+	goto tr390;
+case 299:
+	if ( 49 <= (*( sm->p)) && (*( sm->p)) <= 54 )
+		goto tr392;
+	goto tr372;
+case 107:
 	switch( (*( sm->p)) ) {
-		case 83: goto tr393;
-		case 115: goto tr393;
+		case 35: goto tr125;
+		case 46: goto tr126;
 	}
-	goto tr368;
+	goto tr69;
 case 108:
-	switch( (*( sm->p)) ) {
-		case 83: goto tr128;
-		case 115: goto tr128;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 33 )
+		goto tr127;
+	if ( (*( sm->p)) > 45 ) {
+		if ( 47 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+			goto tr127;
+	} else if ( (*( sm->p)) >= 35 )
+		goto tr127;
+	goto tr69;
 case 109:
 	switch( (*( sm->p)) ) {
-		case 85: goto tr129;
-		case 117: goto tr129;
+		case 33: goto tr128;
+		case 46: goto tr129;
 	}
-	goto tr67;
-case 110:
-	switch( (*( sm->p)) ) {
-		case 69: goto tr130;
-		case 101: goto tr130;
-	}
-	goto tr67;
-case 111:
-	if ( (*( sm->p)) == 32 )
-		goto tr131;
-	goto tr67;
-case 112:
-	if ( (*( sm->p)) == 35 )
-		goto tr132;
-	goto tr67;
-case 113:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr133;
-	goto tr67;
-case 299:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr395;
-	goto tr394;
+	if ( 35 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+		goto tr128;
+	goto tr69;
 case 300:
 	switch( (*( sm->p)) ) {
-		case 73: goto tr396;
-		case 79: goto tr397;
-		case 105: goto tr396;
-		case 111: goto tr397;
+		case 9: goto tr394;
+		case 32: goto tr394;
 	}
-	goto tr368;
-case 114:
-	switch( (*( sm->p)) ) {
-		case 88: goto tr134;
-		case 120: goto tr134;
-	}
-	goto tr67;
-case 115:
-	switch( (*( sm->p)) ) {
-		case 73: goto tr135;
-		case 105: goto tr135;
-	}
-	goto tr67;
-case 116:
-	switch( (*( sm->p)) ) {
-		case 86: goto tr136;
-		case 118: goto tr136;
-	}
-	goto tr67;
-case 117:
-	if ( (*( sm->p)) == 32 )
-		goto tr137;
-	goto tr67;
-case 118:
-	if ( (*( sm->p)) == 35 )
-		goto tr138;
-	goto tr67;
-case 119:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr139;
-	goto tr67;
+	goto tr393;
 case 301:
-	if ( (*( sm->p)) == 47 )
-		goto tr399;
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr400;
-	goto tr398;
-case 120:
-	if ( (*( sm->p)) == 112 )
-		goto tr141;
-	goto tr140;
-case 121:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr142;
-	goto tr140;
+	switch( (*( sm->p)) ) {
+		case 9: goto tr396;
+		case 32: goto tr396;
+	}
+	goto tr395;
 case 302:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr402;
-	goto tr401;
-case 122:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr143;
-		case 83: goto tr144;
-		case 111: goto tr143;
-		case 115: goto tr144;
+		case 83: goto tr397;
+		case 115: goto tr397;
 	}
-	goto tr67;
-case 123:
+	goto tr372;
+case 110:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr145;
-		case 108: goto tr145;
+		case 83: goto tr130;
+		case 115: goto tr130;
 	}
-	goto tr67;
-case 124:
+	goto tr69;
+case 111:
+	switch( (*( sm->p)) ) {
+		case 85: goto tr131;
+		case 117: goto tr131;
+	}
+	goto tr69;
+case 112:
+	switch( (*( sm->p)) ) {
+		case 69: goto tr132;
+		case 101: goto tr132;
+	}
+	goto tr69;
+case 113:
 	if ( (*( sm->p)) == 32 )
-		goto tr146;
-	goto tr67;
-case 125:
+		goto tr133;
+	goto tr69;
+case 114:
 	if ( (*( sm->p)) == 35 )
-		goto tr147;
-	goto tr67;
-case 126:
+		goto tr134;
+	goto tr69;
+case 115:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr148;
-	goto tr67;
+		goto tr135;
+	goto tr69;
 case 303:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr404;
-	goto tr403;
-case 127:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr149;
-		case 116: goto tr149;
-	}
-	goto tr67;
-case 128:
-	if ( (*( sm->p)) == 32 )
-		goto tr150;
-	goto tr67;
-case 129:
-	if ( (*( sm->p)) == 35 )
-		goto tr151;
-	goto tr67;
-case 130:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr152;
-	goto tr67;
+		goto tr399;
+	goto tr398;
 case 304:
+	switch( (*( sm->p)) ) {
+		case 73: goto tr400;
+		case 79: goto tr401;
+		case 105: goto tr400;
+		case 111: goto tr401;
+	}
+	goto tr372;
+case 116:
+	switch( (*( sm->p)) ) {
+		case 88: goto tr136;
+		case 120: goto tr136;
+	}
+	goto tr69;
+case 117:
+	switch( (*( sm->p)) ) {
+		case 73: goto tr137;
+		case 105: goto tr137;
+	}
+	goto tr69;
+case 118:
+	switch( (*( sm->p)) ) {
+		case 86: goto tr138;
+		case 118: goto tr138;
+	}
+	goto tr69;
+case 119:
+	if ( (*( sm->p)) == 32 )
+		goto tr139;
+	goto tr69;
+case 120:
+	if ( (*( sm->p)) == 35 )
+		goto tr140;
+	goto tr69;
+case 121:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr141;
+	goto tr69;
+case 305:
+	if ( (*( sm->p)) == 47 )
+		goto tr403;
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr404;
+	goto tr402;
+case 122:
+	if ( (*( sm->p)) == 112 )
+		goto tr143;
+	goto tr142;
+case 123:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr144;
+	goto tr142;
+case 306:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
 		goto tr406;
 	goto tr405;
-case 305:
+case 124:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr407;
-		case 111: goto tr407;
+		case 79: goto tr145;
+		case 83: goto tr146;
+		case 111: goto tr145;
+		case 115: goto tr146;
 	}
-	goto tr368;
-case 131:
+	goto tr69;
+case 125:
 	switch( (*( sm->p)) ) {
-		case 80: goto tr153;
-		case 112: goto tr153;
+		case 76: goto tr147;
+		case 108: goto tr147;
 	}
-	goto tr67;
-case 132:
-	switch( (*( sm->p)) ) {
-		case 73: goto tr154;
-		case 105: goto tr154;
-	}
-	goto tr67;
-case 133:
-	switch( (*( sm->p)) ) {
-		case 67: goto tr155;
-		case 99: goto tr155;
-	}
-	goto tr67;
-case 134:
+	goto tr69;
+case 126:
 	if ( (*( sm->p)) == 32 )
-		goto tr156;
-	goto tr67;
-case 135:
+		goto tr148;
+	goto tr69;
+case 127:
 	if ( (*( sm->p)) == 35 )
-		goto tr157;
-	goto tr67;
-case 136:
+		goto tr149;
+	goto tr69;
+case 128:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr158;
-	goto tr67;
-case 306:
-	if ( (*( sm->p)) == 47 )
-		goto tr409;
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr410;
-	goto tr408;
-case 137:
-	if ( (*( sm->p)) == 112 )
-		goto tr160;
-	goto tr159;
-case 138:
-	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr161;
-	goto tr159;
+		goto tr150;
+	goto tr69;
 case 307:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr412;
-	goto tr411;
-case 308:
+		goto tr408;
+	goto tr407;
+case 129:
 	switch( (*( sm->p)) ) {
-		case 83: goto tr413;
-		case 115: goto tr413;
+		case 84: goto tr151;
+		case 116: goto tr151;
 	}
-	goto tr368;
-case 139:
-	switch( (*( sm->p)) ) {
-		case 69: goto tr162;
-		case 101: goto tr162;
-	}
-	goto tr67;
-case 140:
-	switch( (*( sm->p)) ) {
-		case 82: goto tr163;
-		case 114: goto tr163;
-	}
-	goto tr67;
-case 141:
+	goto tr69;
+case 130:
 	if ( (*( sm->p)) == 32 )
-		goto tr164;
-	goto tr67;
-case 142:
+		goto tr152;
+	goto tr69;
+case 131:
 	if ( (*( sm->p)) == 35 )
-		goto tr165;
-	goto tr67;
-case 143:
+		goto tr153;
+	goto tr69;
+case 132:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr166;
-	goto tr67;
+		goto tr154;
+	goto tr69;
+case 308:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr410;
+	goto tr409;
 case 309:
+	switch( (*( sm->p)) ) {
+		case 79: goto tr411;
+		case 111: goto tr411;
+	}
+	goto tr372;
+case 133:
+	switch( (*( sm->p)) ) {
+		case 80: goto tr155;
+		case 112: goto tr155;
+	}
+	goto tr69;
+case 134:
+	switch( (*( sm->p)) ) {
+		case 73: goto tr156;
+		case 105: goto tr156;
+	}
+	goto tr69;
+case 135:
+	switch( (*( sm->p)) ) {
+		case 67: goto tr157;
+		case 99: goto tr157;
+	}
+	goto tr69;
+case 136:
+	if ( (*( sm->p)) == 32 )
+		goto tr158;
+	goto tr69;
+case 137:
+	if ( (*( sm->p)) == 35 )
+		goto tr159;
+	goto tr69;
+case 138:
 	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
-		goto tr415;
-	goto tr414;
+		goto tr160;
+	goto tr69;
 case 310:
+	if ( (*( sm->p)) == 47 )
+		goto tr413;
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr414;
+	goto tr412;
+case 139:
+	if ( (*( sm->p)) == 112 )
+		goto tr162;
+	goto tr161;
+case 140:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr163;
+	goto tr161;
+case 311:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr416;
+	goto tr415;
+case 312:
 	switch( (*( sm->p)) ) {
-		case 47: goto tr416;
-		case 66: goto tr417;
-		case 69: goto tr418;
-		case 73: goto tr419;
-		case 78: goto tr420;
-		case 81: goto tr421;
-		case 83: goto tr422;
-		case 84: goto tr423;
-		case 85: goto tr424;
-		case 91: goto tr425;
-		case 98: goto tr417;
-		case 101: goto tr418;
-		case 105: goto tr419;
-		case 110: goto tr420;
-		case 113: goto tr421;
-		case 115: goto tr422;
-		case 116: goto tr423;
-		case 117: goto tr424;
+		case 83: goto tr417;
+		case 115: goto tr417;
 	}
-	goto tr368;
+	goto tr372;
+case 141:
+	switch( (*( sm->p)) ) {
+		case 69: goto tr164;
+		case 101: goto tr164;
+	}
+	goto tr69;
+case 142:
+	switch( (*( sm->p)) ) {
+		case 82: goto tr165;
+		case 114: goto tr165;
+	}
+	goto tr69;
+case 143:
+	if ( (*( sm->p)) == 32 )
+		goto tr166;
+	goto tr69;
 case 144:
-	switch( (*( sm->p)) ) {
-		case 66: goto tr167;
-		case 69: goto tr168;
-		case 73: goto tr169;
-		case 81: goto tr170;
-		case 83: goto tr171;
-		case 84: goto tr172;
-		case 85: goto tr173;
-		case 98: goto tr167;
-		case 101: goto tr168;
-		case 105: goto tr169;
-		case 113: goto tr170;
-		case 115: goto tr171;
-		case 116: goto tr172;
-		case 117: goto tr173;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 35 )
+		goto tr167;
+	goto tr69;
 case 145:
-	if ( (*( sm->p)) == 93 )
-		goto tr174;
-	goto tr67;
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr168;
+	goto tr69;
+case 313:
+	if ( 48 <= (*( sm->p)) && (*( sm->p)) <= 57 )
+		goto tr419;
+	goto tr418;
+case 314:
+	switch( (*( sm->p)) ) {
+		case 47: goto tr420;
+		case 66: goto tr421;
+		case 69: goto tr422;
+		case 73: goto tr423;
+		case 78: goto tr424;
+		case 81: goto tr425;
+		case 83: goto tr426;
+		case 84: goto tr427;
+		case 85: goto tr428;
+		case 91: goto tr429;
+		case 98: goto tr421;
+		case 101: goto tr422;
+		case 105: goto tr423;
+		case 110: goto tr424;
+		case 113: goto tr425;
+		case 115: goto tr426;
+		case 116: goto tr427;
+		case 117: goto tr428;
+	}
+	goto tr372;
 case 146:
 	switch( (*( sm->p)) ) {
-		case 88: goto tr175;
-		case 120: goto tr175;
+		case 66: goto tr169;
+		case 69: goto tr170;
+		case 73: goto tr171;
+		case 81: goto tr172;
+		case 83: goto tr173;
+		case 84: goto tr174;
+		case 85: goto tr175;
+		case 98: goto tr169;
+		case 101: goto tr170;
+		case 105: goto tr171;
+		case 113: goto tr172;
+		case 115: goto tr173;
+		case 116: goto tr174;
+		case 117: goto tr175;
 	}
-	goto tr67;
+	goto tr69;
 case 147:
-	switch( (*( sm->p)) ) {
-		case 80: goto tr176;
-		case 112: goto tr176;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr176;
+	goto tr69;
 case 148:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr177;
-		case 97: goto tr177;
+		case 88: goto tr177;
+		case 120: goto tr177;
 	}
-	goto tr67;
+	goto tr69;
 case 149:
 	switch( (*( sm->p)) ) {
-		case 78: goto tr178;
-		case 110: goto tr178;
+		case 80: goto tr178;
+		case 112: goto tr178;
 	}
-	goto tr67;
+	goto tr69;
 case 150:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr179;
-		case 100: goto tr179;
+		case 65: goto tr179;
+		case 97: goto tr179;
 	}
-	goto tr67;
+	goto tr69;
 case 151:
-	if ( (*( sm->p)) == 93 )
-		goto tr180;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 78: goto tr180;
+		case 110: goto tr180;
+	}
+	goto tr69;
 case 152:
-	if ( (*( sm->p)) == 93 )
-		goto tr181;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 68: goto tr181;
+		case 100: goto tr181;
+	}
+	goto tr69;
 case 153:
-	switch( (*( sm->p)) ) {
-		case 85: goto tr182;
-		case 117: goto tr182;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr182;
+	goto tr69;
 case 154:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr183;
-		case 111: goto tr183;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr183;
+	goto tr69;
 case 155:
 	switch( (*( sm->p)) ) {
-		case 84: goto tr184;
-		case 116: goto tr184;
+		case 85: goto tr184;
+		case 117: goto tr184;
 	}
-	goto tr67;
+	goto tr69;
 case 156:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr185;
-		case 101: goto tr185;
+		case 79: goto tr185;
+		case 111: goto tr185;
 	}
-	goto tr67;
+	goto tr69;
 case 157:
-	if ( (*( sm->p)) == 93 )
-		goto tr186;
-	goto tr67;
-case 311:
-	if ( (*( sm->p)) == 32 )
-		goto tr186;
-	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
-		goto tr186;
-	goto tr426;
+	switch( (*( sm->p)) ) {
+		case 84: goto tr186;
+		case 116: goto tr186;
+	}
+	goto tr69;
 case 158:
 	switch( (*( sm->p)) ) {
-		case 80: goto tr187;
-		case 93: goto tr188;
-		case 112: goto tr187;
+		case 69: goto tr187;
+		case 101: goto tr187;
 	}
-	goto tr67;
+	goto tr69;
 case 159:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr189;
-		case 111: goto tr189;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr188;
+	goto tr69;
+case 315:
+	if ( (*( sm->p)) == 32 )
+		goto tr188;
+	if ( 9 <= (*( sm->p)) && (*( sm->p)) <= 13 )
+		goto tr188;
+	goto tr430;
 case 160:
 	switch( (*( sm->p)) ) {
-		case 73: goto tr190;
-		case 105: goto tr190;
+		case 80: goto tr189;
+		case 93: goto tr190;
+		case 112: goto tr189;
 	}
-	goto tr67;
+	goto tr69;
 case 161:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr191;
-		case 108: goto tr191;
+		case 79: goto tr191;
+		case 111: goto tr191;
 	}
-	goto tr67;
+	goto tr69;
 case 162:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr192;
-		case 101: goto tr192;
+		case 73: goto tr192;
+		case 105: goto tr192;
 	}
-	goto tr67;
+	goto tr69;
 case 163:
 	switch( (*( sm->p)) ) {
-		case 82: goto tr193;
-		case 114: goto tr193;
+		case 76: goto tr193;
+		case 108: goto tr193;
 	}
-	goto tr67;
+	goto tr69;
 case 164:
-	if ( (*( sm->p)) == 93 )
-		goto tr194;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 69: goto tr194;
+		case 101: goto tr194;
+	}
+	goto tr69;
 case 165:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr195;
-		case 72: goto tr196;
-		case 78: goto tr197;
-		case 100: goto tr195;
-		case 104: goto tr196;
-		case 110: goto tr197;
+		case 82: goto tr195;
+		case 114: goto tr195;
 	}
-	goto tr67;
+	goto tr69;
 case 166:
-	if ( (*( sm->p)) == 93 )
-		goto tr198;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 83: goto tr196;
+		case 93: goto tr197;
+		case 115: goto tr196;
+	}
+	goto tr69;
 case 167:
 	if ( (*( sm->p)) == 93 )
-		goto tr199;
-	goto tr67;
+		goto tr197;
+	goto tr69;
 case 168:
-	if ( (*( sm->p)) == 93 )
-		goto tr200;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 68: goto tr198;
+		case 72: goto tr199;
+		case 78: goto tr200;
+		case 100: goto tr198;
+		case 104: goto tr199;
+		case 110: goto tr200;
+	}
+	goto tr69;
 case 169:
 	if ( (*( sm->p)) == 93 )
 		goto tr201;
-	goto tr67;
+	goto tr69;
 case 170:
 	if ( (*( sm->p)) == 93 )
 		goto tr202;
-	goto tr67;
+	goto tr69;
 case 171:
-	switch( (*( sm->p)) ) {
-		case 88: goto tr203;
-		case 120: goto tr203;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr203;
+	goto tr69;
 case 172:
-	switch( (*( sm->p)) ) {
-		case 80: goto tr204;
-		case 112: goto tr204;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr204;
+	goto tr69;
 case 173:
-	switch( (*( sm->p)) ) {
-		case 65: goto tr205;
-		case 97: goto tr205;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr205;
+	goto tr69;
 case 174:
 	switch( (*( sm->p)) ) {
-		case 78: goto tr206;
-		case 110: goto tr206;
+		case 88: goto tr206;
+		case 120: goto tr206;
 	}
-	goto tr67;
+	goto tr69;
 case 175:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr207;
-		case 100: goto tr207;
+		case 80: goto tr207;
+		case 112: goto tr207;
 	}
-	goto tr67;
+	goto tr69;
 case 176:
-	if ( (*( sm->p)) == 93 )
-		goto tr208;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 65: goto tr208;
+		case 97: goto tr208;
+	}
+	goto tr69;
 case 177:
-	if ( (*( sm->p)) == 93 )
-		goto tr209;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 78: goto tr209;
+		case 110: goto tr209;
+	}
+	goto tr69;
 case 178:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr210;
-		case 111: goto tr210;
+		case 68: goto tr210;
+		case 100: goto tr210;
 	}
-	goto tr67;
+	goto tr69;
 case 179:
-	switch( (*( sm->p)) ) {
-		case 68: goto tr211;
-		case 100: goto tr211;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr211;
+	goto tr69;
 case 180:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr212;
-		case 116: goto tr212;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr212;
+	goto tr69;
 case 181:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr213;
-		case 101: goto tr213;
+		case 79: goto tr213;
+		case 111: goto tr213;
 	}
-	goto tr67;
+	goto tr69;
 case 182:
 	switch( (*( sm->p)) ) {
-		case 88: goto tr214;
-		case 120: goto tr214;
+		case 68: goto tr214;
+		case 100: goto tr214;
 	}
-	goto tr67;
+	goto tr69;
 case 183:
 	switch( (*( sm->p)) ) {
 		case 84: goto tr215;
 		case 116: goto tr215;
 	}
-	goto tr67;
+	goto tr69;
 case 184:
-	if ( (*( sm->p)) == 93 )
-		goto tr216;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 69: goto tr216;
+		case 101: goto tr216;
+	}
+	goto tr69;
 case 185:
 	switch( (*( sm->p)) ) {
-		case 85: goto tr217;
-		case 117: goto tr217;
+		case 88: goto tr217;
+		case 120: goto tr217;
 	}
-	goto tr67;
+	goto tr69;
 case 186:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr218;
-		case 111: goto tr218;
+		case 84: goto tr218;
+		case 116: goto tr218;
 	}
-	goto tr67;
+	goto tr69;
 case 187:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr219;
-		case 116: goto tr219;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr219;
+	goto tr69;
 case 188:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr220;
-		case 101: goto tr220;
+		case 85: goto tr220;
+		case 117: goto tr220;
 	}
-	goto tr67;
+	goto tr69;
 case 189:
-	if ( (*( sm->p)) == 93 )
-		goto tr221;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 79: goto tr221;
+		case 111: goto tr221;
+	}
+	goto tr69;
 case 190:
 	switch( (*( sm->p)) ) {
-		case 80: goto tr222;
-		case 93: goto tr223;
-		case 112: goto tr222;
+		case 84: goto tr222;
+		case 116: goto tr222;
 	}
-	goto tr67;
+	goto tr69;
 case 191:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr224;
-		case 111: goto tr224;
+		case 69: goto tr223;
+		case 101: goto tr223;
 	}
-	goto tr67;
+	goto tr69;
 case 192:
-	switch( (*( sm->p)) ) {
-		case 73: goto tr225;
-		case 105: goto tr225;
-	}
-	goto tr67;
+	if ( (*( sm->p)) == 93 )
+		goto tr224;
+	goto tr69;
 case 193:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr226;
-		case 108: goto tr226;
+		case 80: goto tr225;
+		case 93: goto tr226;
+		case 112: goto tr225;
 	}
-	goto tr67;
+	goto tr69;
 case 194:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr227;
-		case 101: goto tr227;
+		case 79: goto tr227;
+		case 111: goto tr227;
 	}
-	goto tr67;
+	goto tr69;
 case 195:
 	switch( (*( sm->p)) ) {
-		case 82: goto tr228;
-		case 114: goto tr228;
+		case 73: goto tr228;
+		case 105: goto tr228;
 	}
-	goto tr67;
+	goto tr69;
 case 196:
-	if ( (*( sm->p)) == 93 )
-		goto tr229;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 76: goto tr229;
+		case 108: goto tr229;
+	}
+	goto tr69;
 case 197:
 	switch( (*( sm->p)) ) {
-		case 78: goto tr230;
-		case 110: goto tr230;
+		case 69: goto tr230;
+		case 101: goto tr230;
 	}
-	goto tr67;
+	goto tr69;
 case 198:
-	if ( (*( sm->p)) == 93 )
-		goto tr231;
-	goto tr67;
-case 199:
-	if ( (*( sm->p)) == 93 )
-		goto tr232;
-	goto tr67;
-case 200:
 	switch( (*( sm->p)) ) {
-		case 93: goto tr67;
-		case 124: goto tr234;
+		case 82: goto tr231;
+		case 114: goto tr231;
 	}
-	goto tr233;
+	goto tr69;
+case 199:
+	switch( (*( sm->p)) ) {
+		case 83: goto tr232;
+		case 93: goto tr233;
+		case 115: goto tr232;
+	}
+	goto tr69;
+case 200:
+	if ( (*( sm->p)) == 93 )
+		goto tr233;
+	goto tr69;
 case 201:
 	switch( (*( sm->p)) ) {
-		case 93: goto tr236;
-		case 124: goto tr237;
+		case 78: goto tr234;
+		case 110: goto tr234;
 	}
-	goto tr235;
+	goto tr69;
 case 202:
 	if ( (*( sm->p)) == 93 )
-		goto tr238;
-	goto tr67;
+		goto tr235;
+	goto tr69;
 case 203:
-	switch( (*( sm->p)) ) {
-		case 93: goto tr67;
-		case 124: goto tr67;
-	}
-	goto tr239;
+	if ( (*( sm->p)) == 93 )
+		goto tr236;
+	goto tr69;
 case 204:
 	switch( (*( sm->p)) ) {
-		case 93: goto tr241;
-		case 124: goto tr67;
+		case 93: goto tr69;
+		case 124: goto tr238;
 	}
-	goto tr240;
+	goto tr237;
 case 205:
+	switch( (*( sm->p)) ) {
+		case 93: goto tr240;
+		case 124: goto tr241;
+	}
+	goto tr239;
+case 206:
 	if ( (*( sm->p)) == 93 )
 		goto tr242;
-	goto tr67;
-case 206:
+	goto tr69;
+case 207:
 	switch( (*( sm->p)) ) {
-		case 93: goto tr236;
-		case 124: goto tr67;
+		case 93: goto tr69;
+		case 124: goto tr69;
 	}
 	goto tr243;
-case 312:
-	if ( (*( sm->p)) == 116 )
-		goto tr427;
-	if ( 49 <= (*( sm->p)) && (*( sm->p)) <= 54 )
-		goto tr388;
-	goto tr368;
-case 207:
-	if ( (*( sm->p)) == 116 )
-		goto tr244;
-	goto tr67;
 case 208:
-	if ( (*( sm->p)) == 112 )
-		goto tr245;
-	goto tr67;
+	switch( (*( sm->p)) ) {
+		case 93: goto tr245;
+		case 124: goto tr69;
+	}
+	goto tr244;
 case 209:
-	switch( (*( sm->p)) ) {
-		case 58: goto tr246;
-		case 115: goto tr247;
-	}
-	goto tr67;
-case 210:
-	if ( (*( sm->p)) == 47 )
-		goto tr248;
-	goto tr67;
-case 211:
-	if ( (*( sm->p)) == 47 )
-		goto tr249;
-	goto tr67;
-case 212:
-	if ( (*( sm->p)) < -32 ) {
-		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr250;
-	} else if ( (*( sm->p)) > -17 ) {
-		if ( (*( sm->p)) > -12 ) {
-			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr253;
-		} else if ( (*( sm->p)) >= -16 )
-			goto tr252;
-	} else
-		goto tr251;
-	goto tr67;
-case 213:
-	if ( (*( sm->p)) <= -65 )
-		goto tr253;
-	goto tr60;
-case 313:
-	if ( (*( sm->p)) < -32 ) {
-		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
-			goto tr250;
-	} else if ( (*( sm->p)) > -17 ) {
-		if ( (*( sm->p)) > -12 ) {
-			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
-				goto tr253;
-		} else if ( (*( sm->p)) >= -16 )
-			goto tr252;
-	} else
-		goto tr251;
-	goto tr428;
-case 214:
-	if ( (*( sm->p)) <= -65 )
-		goto tr250;
-	goto tr60;
-case 215:
-	if ( (*( sm->p)) <= -65 )
-		goto tr251;
-	goto tr60;
-case 216:
-	if ( (*( sm->p)) == 58 )
+	if ( (*( sm->p)) == 93 )
 		goto tr246;
-	goto tr67;
-case 314:
-	if ( (*( sm->p)) == 123 )
-		goto tr429;
-	goto tr368;
-case 217:
-	if ( (*( sm->p)) == 125 )
-		goto tr67;
-	goto tr254;
-case 218:
-	if ( (*( sm->p)) == 125 )
-		goto tr256;
-	goto tr255;
-case 219:
-	if ( (*( sm->p)) == 125 )
-		goto tr257;
-	goto tr67;
-case 315:
+	goto tr69;
+case 210:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr431;
-		case 91: goto tr432;
+		case 93: goto tr240;
+		case 124: goto tr69;
 	}
-	goto tr430;
+	goto tr247;
 case 316:
+	if ( (*( sm->p)) == 116 )
+		goto tr431;
+	if ( 49 <= (*( sm->p)) && (*( sm->p)) <= 54 )
+		goto tr392;
+	goto tr372;
+case 211:
+	if ( (*( sm->p)) == 116 )
+		goto tr248;
+	goto tr69;
+case 212:
+	if ( (*( sm->p)) == 112 )
+		goto tr249;
+	goto tr69;
+case 213:
+	switch( (*( sm->p)) ) {
+		case 58: goto tr250;
+		case 115: goto tr251;
+	}
+	goto tr69;
+case 214:
 	if ( (*( sm->p)) == 47 )
-		goto tr434;
-	goto tr433;
+		goto tr252;
+	goto tr69;
+case 215:
+	if ( (*( sm->p)) == 47 )
+		goto tr253;
+	goto tr69;
+case 216:
+	if ( (*( sm->p)) < -32 ) {
+		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
+			goto tr254;
+	} else if ( (*( sm->p)) > -17 ) {
+		if ( (*( sm->p)) > -12 ) {
+			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+				goto tr257;
+		} else if ( (*( sm->p)) >= -16 )
+			goto tr256;
+	} else
+		goto tr255;
+	goto tr69;
+case 217:
+	if ( (*( sm->p)) <= -65 )
+		goto tr257;
+	goto tr62;
+case 317:
+	if ( (*( sm->p)) < -32 ) {
+		if ( -62 <= (*( sm->p)) && (*( sm->p)) <= -33 )
+			goto tr254;
+	} else if ( (*( sm->p)) > -17 ) {
+		if ( (*( sm->p)) > -12 ) {
+			if ( 33 <= (*( sm->p)) && (*( sm->p)) <= 126 )
+				goto tr257;
+		} else if ( (*( sm->p)) >= -16 )
+			goto tr256;
+	} else
+		goto tr255;
+	goto tr432;
+case 218:
+	if ( (*( sm->p)) <= -65 )
+		goto tr254;
+	goto tr62;
+case 219:
+	if ( (*( sm->p)) <= -65 )
+		goto tr255;
+	goto tr62;
 case 220:
-	switch( (*( sm->p)) ) {
-		case 67: goto tr259;
-		case 99: goto tr259;
-	}
-	goto tr258;
+	if ( (*( sm->p)) == 58 )
+		goto tr250;
+	goto tr69;
+case 318:
+	if ( (*( sm->p)) == 123 )
+		goto tr433;
+	goto tr372;
 case 221:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr260;
-		case 111: goto tr260;
-	}
+	if ( (*( sm->p)) == 125 )
+		goto tr69;
 	goto tr258;
 case 222:
-	switch( (*( sm->p)) ) {
-		case 68: goto tr261;
-		case 100: goto tr261;
-	}
-	goto tr258;
+	if ( (*( sm->p)) == 125 )
+		goto tr260;
+	goto tr259;
 case 223:
-	switch( (*( sm->p)) ) {
-		case 69: goto tr262;
-		case 101: goto tr262;
-	}
-	goto tr258;
-case 224:
-	if ( (*( sm->p)) == 93 )
-		goto tr263;
-	goto tr258;
-case 317:
-	switch( (*( sm->p)) ) {
-		case 0: goto tr436;
-		case 91: goto tr437;
-	}
-	goto tr435;
-case 318:
-	if ( (*( sm->p)) == 47 )
-		goto tr439;
-	goto tr438;
-case 225:
-	switch( (*( sm->p)) ) {
-		case 78: goto tr265;
-		case 110: goto tr265;
-	}
-	goto tr264;
-case 226:
-	switch( (*( sm->p)) ) {
-		case 79: goto tr266;
-		case 111: goto tr266;
-	}
-	goto tr264;
-case 227:
-	switch( (*( sm->p)) ) {
-		case 68: goto tr267;
-		case 100: goto tr267;
-	}
-	goto tr264;
-case 228:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr268;
-		case 116: goto tr268;
-	}
-	goto tr264;
-case 229:
-	switch( (*( sm->p)) ) {
-		case 69: goto tr269;
-		case 101: goto tr269;
-	}
-	goto tr264;
-case 230:
-	switch( (*( sm->p)) ) {
-		case 88: goto tr270;
-		case 120: goto tr270;
-	}
-	goto tr264;
-case 231:
-	switch( (*( sm->p)) ) {
-		case 84: goto tr271;
-		case 116: goto tr271;
-	}
-	goto tr264;
-case 232:
-	if ( (*( sm->p)) == 93 )
-		goto tr272;
-	goto tr264;
+	if ( (*( sm->p)) == 125 )
+		goto tr261;
+	goto tr69;
 case 319:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr441;
-		case 91: goto tr442;
+		case 0: goto tr435;
+		case 91: goto tr436;
 	}
-	goto tr440;
+	goto tr434;
 case 320:
+	if ( (*( sm->p)) == 47 )
+		goto tr438;
+	goto tr437;
+case 224:
 	switch( (*( sm->p)) ) {
-		case 47: goto tr444;
-		case 84: goto tr445;
-		case 116: goto tr445;
+		case 67: goto tr263;
+		case 99: goto tr263;
 	}
-	goto tr443;
+	goto tr262;
+case 225:
+	switch( (*( sm->p)) ) {
+		case 79: goto tr264;
+		case 111: goto tr264;
+	}
+	goto tr262;
+case 226:
+	switch( (*( sm->p)) ) {
+		case 68: goto tr265;
+		case 100: goto tr265;
+	}
+	goto tr262;
+case 227:
+	switch( (*( sm->p)) ) {
+		case 69: goto tr266;
+		case 101: goto tr266;
+	}
+	goto tr262;
+case 228:
+	if ( (*( sm->p)) == 93 )
+		goto tr267;
+	goto tr262;
+case 321:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr440;
+		case 91: goto tr441;
+	}
+	goto tr439;
+case 322:
+	if ( (*( sm->p)) == 47 )
+		goto tr443;
+	goto tr442;
+case 229:
+	switch( (*( sm->p)) ) {
+		case 78: goto tr269;
+		case 110: goto tr269;
+	}
+	goto tr268;
+case 230:
+	switch( (*( sm->p)) ) {
+		case 79: goto tr270;
+		case 111: goto tr270;
+	}
+	goto tr268;
+case 231:
+	switch( (*( sm->p)) ) {
+		case 68: goto tr271;
+		case 100: goto tr271;
+	}
+	goto tr268;
+case 232:
+	switch( (*( sm->p)) ) {
+		case 84: goto tr272;
+		case 116: goto tr272;
+	}
+	goto tr268;
 case 233:
 	switch( (*( sm->p)) ) {
-		case 84: goto tr274;
-		case 116: goto tr274;
+		case 69: goto tr273;
+		case 101: goto tr273;
 	}
-	goto tr273;
+	goto tr268;
 case 234:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr275;
-		case 66: goto tr276;
-		case 72: goto tr277;
-		case 82: goto tr278;
-		case 97: goto tr275;
-		case 98: goto tr276;
-		case 104: goto tr277;
-		case 114: goto tr278;
+		case 88: goto tr274;
+		case 120: goto tr274;
 	}
-	goto tr273;
+	goto tr268;
 case 235:
 	switch( (*( sm->p)) ) {
-		case 66: goto tr279;
-		case 98: goto tr279;
+		case 84: goto tr275;
+		case 116: goto tr275;
 	}
-	goto tr273;
+	goto tr268;
 case 236:
+	if ( (*( sm->p)) == 93 )
+		goto tr276;
+	goto tr268;
+case 323:
 	switch( (*( sm->p)) ) {
-		case 76: goto tr280;
-		case 108: goto tr280;
+		case 0: goto tr445;
+		case 91: goto tr446;
 	}
-	goto tr273;
+	goto tr444;
+case 324:
+	switch( (*( sm->p)) ) {
+		case 47: goto tr448;
+		case 84: goto tr449;
+		case 116: goto tr449;
+	}
+	goto tr447;
 case 237:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr281;
-		case 101: goto tr281;
+		case 84: goto tr278;
+		case 116: goto tr278;
 	}
-	goto tr273;
+	goto tr277;
 case 238:
-	if ( (*( sm->p)) == 93 )
-		goto tr282;
-	goto tr273;
+	switch( (*( sm->p)) ) {
+		case 65: goto tr279;
+		case 66: goto tr280;
+		case 72: goto tr281;
+		case 82: goto tr282;
+		case 97: goto tr279;
+		case 98: goto tr280;
+		case 104: goto tr281;
+		case 114: goto tr282;
+	}
+	goto tr277;
 case 239:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr283;
-		case 111: goto tr283;
+		case 66: goto tr283;
+		case 98: goto tr283;
 	}
-	goto tr273;
+	goto tr277;
 case 240:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr284;
-		case 100: goto tr284;
+		case 76: goto tr284;
+		case 108: goto tr284;
 	}
-	goto tr273;
+	goto tr277;
 case 241:
 	switch( (*( sm->p)) ) {
-		case 89: goto tr285;
-		case 121: goto tr285;
+		case 69: goto tr285;
+		case 101: goto tr285;
 	}
-	goto tr273;
+	goto tr277;
 case 242:
 	if ( (*( sm->p)) == 93 )
 		goto tr286;
-	goto tr273;
+	goto tr277;
 case 243:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr287;
-		case 101: goto tr287;
+		case 79: goto tr287;
+		case 111: goto tr287;
 	}
-	goto tr273;
+	goto tr277;
 case 244:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr288;
-		case 97: goto tr288;
+		case 68: goto tr288;
+		case 100: goto tr288;
 	}
-	goto tr273;
+	goto tr277;
 case 245:
 	switch( (*( sm->p)) ) {
-		case 68: goto tr289;
-		case 100: goto tr289;
+		case 89: goto tr289;
+		case 121: goto tr289;
 	}
-	goto tr273;
+	goto tr277;
 case 246:
 	if ( (*( sm->p)) == 93 )
 		goto tr290;
-	goto tr273;
+	goto tr277;
 case 247:
-	if ( (*( sm->p)) == 93 )
-		goto tr291;
-	goto tr273;
+	switch( (*( sm->p)) ) {
+		case 69: goto tr291;
+		case 101: goto tr291;
+	}
+	goto tr277;
 case 248:
 	switch( (*( sm->p)) ) {
-		case 66: goto tr292;
-		case 68: goto tr293;
-		case 72: goto tr294;
-		case 82: goto tr295;
-		case 98: goto tr292;
-		case 100: goto tr293;
-		case 104: goto tr294;
-		case 114: goto tr295;
+		case 65: goto tr292;
+		case 97: goto tr292;
 	}
-	goto tr273;
+	goto tr277;
 case 249:
 	switch( (*( sm->p)) ) {
-		case 79: goto tr296;
-		case 111: goto tr296;
+		case 68: goto tr293;
+		case 100: goto tr293;
 	}
-	goto tr273;
+	goto tr277;
 case 250:
-	switch( (*( sm->p)) ) {
-		case 68: goto tr297;
-		case 100: goto tr297;
-	}
-	goto tr273;
+	if ( (*( sm->p)) == 93 )
+		goto tr294;
+	goto tr277;
 case 251:
-	switch( (*( sm->p)) ) {
-		case 89: goto tr298;
-		case 121: goto tr298;
-	}
-	goto tr273;
+	if ( (*( sm->p)) == 93 )
+		goto tr295;
+	goto tr277;
 case 252:
-	if ( (*( sm->p)) == 93 )
-		goto tr299;
-	goto tr273;
+	switch( (*( sm->p)) ) {
+		case 66: goto tr296;
+		case 68: goto tr297;
+		case 72: goto tr298;
+		case 82: goto tr299;
+		case 98: goto tr296;
+		case 100: goto tr297;
+		case 104: goto tr298;
+		case 114: goto tr299;
+	}
+	goto tr277;
 case 253:
-	if ( (*( sm->p)) == 93 )
-		goto tr300;
-	goto tr273;
+	switch( (*( sm->p)) ) {
+		case 79: goto tr300;
+		case 111: goto tr300;
+	}
+	goto tr277;
 case 254:
 	switch( (*( sm->p)) ) {
-		case 69: goto tr301;
-		case 93: goto tr302;
-		case 101: goto tr301;
+		case 68: goto tr301;
+		case 100: goto tr301;
 	}
-	goto tr273;
+	goto tr277;
 case 255:
 	switch( (*( sm->p)) ) {
-		case 65: goto tr303;
-		case 97: goto tr303;
+		case 89: goto tr302;
+		case 121: goto tr302;
 	}
-	goto tr273;
+	goto tr277;
 case 256:
-	switch( (*( sm->p)) ) {
-		case 68: goto tr304;
-		case 100: goto tr304;
-	}
-	goto tr273;
+	if ( (*( sm->p)) == 93 )
+		goto tr303;
+	goto tr277;
 case 257:
 	if ( (*( sm->p)) == 93 )
-		goto tr305;
-	goto tr273;
+		goto tr304;
+	goto tr277;
 case 258:
-	if ( (*( sm->p)) == 93 )
-		goto tr306;
-	goto tr273;
-case 321:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr447;
-		case 10: goto tr448;
-		case 13: goto tr449;
-		case 42: goto tr450;
+		case 69: goto tr305;
+		case 93: goto tr306;
+		case 101: goto tr305;
 	}
-	goto tr446;
-case 322:
-	switch( (*( sm->p)) ) {
-		case 10: goto tr308;
-		case 13: goto tr451;
-	}
-	goto tr307;
+	goto tr277;
 case 259:
-	if ( (*( sm->p)) == 10 )
-		goto tr308;
-	goto tr307;
-case 323:
-	if ( (*( sm->p)) == 10 )
-		goto tr448;
-	goto tr452;
-case 324:
 	switch( (*( sm->p)) ) {
-		case 9: goto tr312;
-		case 32: goto tr312;
-		case 42: goto tr313;
+		case 65: goto tr307;
+		case 97: goto tr307;
 	}
-	goto tr452;
+	goto tr277;
 case 260:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr309;
-		case 9: goto tr311;
-		case 10: goto tr309;
-		case 13: goto tr309;
-		case 32: goto tr311;
+		case 68: goto tr308;
+		case 100: goto tr308;
 	}
-	goto tr310;
+	goto tr277;
+case 261:
+	if ( (*( sm->p)) == 93 )
+		goto tr309;
+	goto tr277;
+case 262:
+	if ( (*( sm->p)) == 93 )
+		goto tr310;
+	goto tr277;
 case 325:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr453;
-		case 10: goto tr453;
+		case 0: goto tr451;
+		case 10: goto tr452;
 		case 13: goto tr453;
+		case 42: goto tr454;
 	}
-	goto tr454;
+	goto tr450;
 case 326:
 	switch( (*( sm->p)) ) {
-		case 0: goto tr453;
-		case 9: goto tr311;
-		case 10: goto tr453;
-		case 13: goto tr453;
-		case 32: goto tr311;
+		case 10: goto tr312;
+		case 13: goto tr455;
 	}
-	goto tr310;
-case 261:
+	goto tr311;
+case 263:
+	if ( (*( sm->p)) == 10 )
+		goto tr312;
+	goto tr311;
+case 327:
+	if ( (*( sm->p)) == 10 )
+		goto tr452;
+	goto tr456;
+case 328:
 	switch( (*( sm->p)) ) {
-		case 9: goto tr312;
-		case 32: goto tr312;
-		case 42: goto tr313;
+		case 9: goto tr316;
+		case 32: goto tr316;
+		case 42: goto tr317;
 	}
-	goto tr309;
+	goto tr456;
+case 264:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr313;
+		case 9: goto tr315;
+		case 10: goto tr313;
+		case 13: goto tr313;
+		case 32: goto tr315;
+	}
+	goto tr314;
+case 329:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr457;
+		case 10: goto tr457;
+		case 13: goto tr457;
+	}
+	goto tr458;
+case 330:
+	switch( (*( sm->p)) ) {
+		case 0: goto tr457;
+		case 9: goto tr315;
+		case 10: goto tr457;
+		case 13: goto tr457;
+		case 32: goto tr315;
+	}
+	goto tr314;
+case 265:
+	switch( (*( sm->p)) ) {
+		case 9: goto tr316;
+		case 32: goto tr316;
+		case 42: goto tr317;
+	}
+	goto tr313;
 	}
 
-	tr321:  sm->cs = 0; goto _again;
+	tr325:  sm->cs = 0; goto _again;
 	tr5:  sm->cs = 1; goto f4;
 	tr6:  sm->cs = 2; goto _again;
-	tr325:  sm->cs = 3; goto f7;
+	tr329:  sm->cs = 3; goto f7;
 	tr7:  sm->cs = 4; goto f4;
 	tr10:  sm->cs = 5; goto _again;
 	tr9:  sm->cs = 5; goto f3;
-	tr330:  sm->cs = 6; goto _again;
+	tr334:  sm->cs = 6; goto _again;
 	tr12:  sm->cs = 7; goto _again;
 	tr13:  sm->cs = 8; goto _again;
 	tr14:  sm->cs = 9; goto _again;
@@ -2461,446 +2491,450 @@ case 261:
 	tr16:  sm->cs = 11; goto _again;
 	tr17:  sm->cs = 12; goto _again;
 	tr18:  sm->cs = 13; goto _again;
-	tr331:  sm->cs = 14; goto _again;
-	tr20:  sm->cs = 15; goto _again;
+	tr19:  sm->cs = 14; goto _again;
+	tr335:  sm->cs = 15; goto _again;
 	tr21:  sm->cs = 16; goto _again;
 	tr22:  sm->cs = 17; goto _again;
-	tr332:  sm->cs = 18; goto _again;
-	tr24:  sm->cs = 19; goto _again;
+	tr23:  sm->cs = 18; goto _again;
+	tr336:  sm->cs = 19; goto _again;
 	tr25:  sm->cs = 20; goto _again;
 	tr26:  sm->cs = 21; goto _again;
 	tr27:  sm->cs = 22; goto _again;
 	tr28:  sm->cs = 23; goto _again;
 	tr29:  sm->cs = 24; goto _again;
-	tr32:  sm->cs = 25; goto _again;
-	tr31:  sm->cs = 25; goto f7;
-	tr333:  sm->cs = 26; goto _again;
-	tr34:  sm->cs = 27; goto _again;
+	tr30:  sm->cs = 25; goto _again;
+	tr33:  sm->cs = 26; goto _again;
+	tr32:  sm->cs = 26; goto f7;
+	tr337:  sm->cs = 27; goto _again;
 	tr35:  sm->cs = 28; goto _again;
 	tr36:  sm->cs = 29; goto _again;
 	tr37:  sm->cs = 30; goto _again;
 	tr38:  sm->cs = 31; goto _again;
 	tr39:  sm->cs = 32; goto _again;
-	tr334:  sm->cs = 33; goto _again;
-	tr41:  sm->cs = 34; goto _again;
+	tr40:  sm->cs = 33; goto _again;
+	tr338:  sm->cs = 34; goto _again;
 	tr42:  sm->cs = 35; goto _again;
 	tr43:  sm->cs = 36; goto _again;
 	tr44:  sm->cs = 37; goto _again;
-	tr335:  sm->cs = 38; goto _again;
-	tr46:  sm->cs = 39; goto _again;
+	tr45:  sm->cs = 38; goto _again;
+	tr339:  sm->cs = 39; goto _again;
 	tr47:  sm->cs = 40; goto _again;
 	tr48:  sm->cs = 41; goto _again;
 	tr49:  sm->cs = 42; goto _again;
 	tr50:  sm->cs = 43; goto _again;
 	tr51:  sm->cs = 44; goto _again;
-	tr336:  sm->cs = 45; goto _again;
+	tr52:  sm->cs = 45; goto _again;
 	tr53:  sm->cs = 46; goto _again;
-	tr55:  sm->cs = 47; goto _again;
-	tr56:  sm->cs = 48; goto _again;
+	tr340:  sm->cs = 47; goto _again;
+	tr55:  sm->cs = 48; goto _again;
 	tr57:  sm->cs = 49; goto _again;
-	tr54:  sm->cs = 50; goto _again;
-	tr362:  sm->cs = 51; goto _again;
-	tr64:  sm->cs = 52; goto _again;
-	tr363:  sm->cs = 52; goto f7;
-	tr63:  sm->cs = 53; goto f4;
-	tr68:  sm->cs = 54; goto _again;
-	tr369:  sm->cs = 54; goto f7;
-	tr69:  sm->cs = 55; goto f4;
+	tr58:  sm->cs = 50; goto _again;
+	tr59:  sm->cs = 51; goto _again;
+	tr56:  sm->cs = 52; goto _again;
+	tr366:  sm->cs = 53; goto _again;
+	tr66:  sm->cs = 54; goto _again;
+	tr367:  sm->cs = 54; goto f7;
+	tr65:  sm->cs = 55; goto f4;
 	tr70:  sm->cs = 56; goto _again;
-	tr98:  sm->cs = 57; goto _again;
-	tr71:  sm->cs = 57; goto f3;
-	tr74:  sm->cs = 58; goto _again;
-	tr75:  sm->cs = 59; goto _again;
+	tr373:  sm->cs = 56; goto f7;
+	tr71:  sm->cs = 57; goto f4;
+	tr72:  sm->cs = 58; goto _again;
+	tr100:  sm->cs = 59; goto _again;
+	tr73:  sm->cs = 59; goto f3;
 	tr76:  sm->cs = 60; goto _again;
-	tr72:  sm->cs = 61; goto _again;
-	tr91:  sm->cs = 62; goto _again;
-	tr78:  sm->cs = 62; goto f3;
-	tr80:  sm->cs = 63; goto _again;
-	tr83:  sm->cs = 64; goto _again;
-	tr81:  sm->cs = 65; goto _again;
-	tr82:  sm->cs = 66; goto _again;
-	tr79:  sm->cs = 67; goto f3;
-	tr85:  sm->cs = 68; goto _again;
-	tr86:  sm->cs = 69; goto _again;
+	tr77:  sm->cs = 61; goto _again;
+	tr78:  sm->cs = 62; goto _again;
+	tr74:  sm->cs = 63; goto _again;
+	tr93:  sm->cs = 64; goto _again;
+	tr80:  sm->cs = 64; goto f3;
+	tr82:  sm->cs = 65; goto _again;
+	tr85:  sm->cs = 66; goto _again;
+	tr83:  sm->cs = 67; goto _again;
+	tr84:  sm->cs = 68; goto _again;
+	tr81:  sm->cs = 69; goto f3;
 	tr87:  sm->cs = 70; goto _again;
 	tr88:  sm->cs = 71; goto _again;
-	tr90:  sm->cs = 72; goto _again;
-	tr89:  sm->cs = 73; goto _again;
-	tr73:  sm->cs = 74; goto f3;
-	tr92:  sm->cs = 75; goto _again;
-	tr93:  sm->cs = 76; goto _again;
+	tr89:  sm->cs = 72; goto _again;
+	tr90:  sm->cs = 73; goto _again;
+	tr92:  sm->cs = 74; goto _again;
+	tr91:  sm->cs = 75; goto _again;
+	tr75:  sm->cs = 76; goto f3;
 	tr94:  sm->cs = 77; goto _again;
 	tr95:  sm->cs = 78; goto _again;
-	tr97:  sm->cs = 79; goto _again;
-	tr96:  sm->cs = 80; goto _again;
-	tr100:  sm->cs = 81; goto _again;
-	tr371:  sm->cs = 81; goto f7;
-	tr101:  sm->cs = 82; goto _again;
-	tr372:  sm->cs = 82; goto f7;
-	tr376:  sm->cs = 83; goto _again;
-	tr373:  sm->cs = 83; goto f7;
-	tr379:  sm->cs = 84; goto _again;
-	tr102:  sm->cs = 85; goto _again;
-	tr103:  sm->cs = 86; goto _again;
+	tr96:  sm->cs = 79; goto _again;
+	tr97:  sm->cs = 80; goto _again;
+	tr99:  sm->cs = 81; goto _again;
+	tr98:  sm->cs = 82; goto _again;
+	tr102:  sm->cs = 83; goto _again;
+	tr375:  sm->cs = 83; goto f7;
+	tr103:  sm->cs = 84; goto _again;
+	tr376:  sm->cs = 84; goto f7;
+	tr380:  sm->cs = 85; goto _again;
+	tr377:  sm->cs = 85; goto f7;
+	tr383:  sm->cs = 86; goto _again;
 	tr104:  sm->cs = 87; goto _again;
 	tr105:  sm->cs = 88; goto _again;
 	tr106:  sm->cs = 89; goto _again;
 	tr107:  sm->cs = 90; goto _again;
-	tr382:  sm->cs = 91; goto _again;
+	tr108:  sm->cs = 91; goto _again;
 	tr109:  sm->cs = 92; goto _again;
-	tr110:  sm->cs = 93; goto _again;
+	tr386:  sm->cs = 93; goto _again;
 	tr111:  sm->cs = 94; goto _again;
 	tr112:  sm->cs = 95; goto _again;
 	tr113:  sm->cs = 96; goto _again;
 	tr114:  sm->cs = 97; goto _again;
 	tr115:  sm->cs = 98; goto _again;
-	tr385:  sm->cs = 99; goto _again;
+	tr116:  sm->cs = 99; goto _again;
 	tr117:  sm->cs = 100; goto _again;
-	tr118:  sm->cs = 101; goto _again;
+	tr389:  sm->cs = 101; goto _again;
 	tr119:  sm->cs = 102; goto _again;
 	tr120:  sm->cs = 103; goto _again;
 	tr121:  sm->cs = 104; goto _again;
-	tr388:  sm->cs = 105; goto f7;
-	tr123:  sm->cs = 106; goto f4;
-	tr126:  sm->cs = 107; goto _again;
-	tr125:  sm->cs = 107; goto f3;
-	tr393:  sm->cs = 108; goto _again;
+	tr122:  sm->cs = 105; goto _again;
+	tr123:  sm->cs = 106; goto _again;
+	tr392:  sm->cs = 107; goto f7;
+	tr125:  sm->cs = 108; goto f4;
 	tr128:  sm->cs = 109; goto _again;
-	tr129:  sm->cs = 110; goto _again;
+	tr127:  sm->cs = 109; goto f3;
+	tr397:  sm->cs = 110; goto _again;
 	tr130:  sm->cs = 111; goto _again;
 	tr131:  sm->cs = 112; goto _again;
 	tr132:  sm->cs = 113; goto _again;
-	tr396:  sm->cs = 114; goto _again;
+	tr133:  sm->cs = 114; goto _again;
 	tr134:  sm->cs = 115; goto _again;
-	tr135:  sm->cs = 116; goto _again;
+	tr400:  sm->cs = 116; goto _again;
 	tr136:  sm->cs = 117; goto _again;
 	tr137:  sm->cs = 118; goto _again;
 	tr138:  sm->cs = 119; goto _again;
-	tr399:  sm->cs = 120; goto f4;
-	tr141:  sm->cs = 121; goto _again;
-	tr397:  sm->cs = 122; goto _again;
+	tr139:  sm->cs = 120; goto _again;
+	tr140:  sm->cs = 121; goto _again;
+	tr403:  sm->cs = 122; goto f4;
 	tr143:  sm->cs = 123; goto _again;
-	tr145:  sm->cs = 124; goto _again;
-	tr146:  sm->cs = 125; goto _again;
+	tr401:  sm->cs = 124; goto _again;
+	tr145:  sm->cs = 125; goto _again;
 	tr147:  sm->cs = 126; goto _again;
-	tr144:  sm->cs = 127; goto _again;
+	tr148:  sm->cs = 127; goto _again;
 	tr149:  sm->cs = 128; goto _again;
-	tr150:  sm->cs = 129; goto _again;
+	tr146:  sm->cs = 129; goto _again;
 	tr151:  sm->cs = 130; goto _again;
-	tr407:  sm->cs = 131; goto _again;
+	tr152:  sm->cs = 131; goto _again;
 	tr153:  sm->cs = 132; goto _again;
-	tr154:  sm->cs = 133; goto _again;
+	tr411:  sm->cs = 133; goto _again;
 	tr155:  sm->cs = 134; goto _again;
 	tr156:  sm->cs = 135; goto _again;
 	tr157:  sm->cs = 136; goto _again;
-	tr409:  sm->cs = 137; goto f4;
-	tr160:  sm->cs = 138; goto _again;
-	tr413:  sm->cs = 139; goto _again;
+	tr158:  sm->cs = 137; goto _again;
+	tr159:  sm->cs = 138; goto _again;
+	tr413:  sm->cs = 139; goto f4;
 	tr162:  sm->cs = 140; goto _again;
-	tr163:  sm->cs = 141; goto _again;
+	tr417:  sm->cs = 141; goto _again;
 	tr164:  sm->cs = 142; goto _again;
 	tr165:  sm->cs = 143; goto _again;
-	tr416:  sm->cs = 144; goto _again;
+	tr166:  sm->cs = 144; goto _again;
 	tr167:  sm->cs = 145; goto _again;
-	tr168:  sm->cs = 146; goto _again;
-	tr175:  sm->cs = 147; goto _again;
-	tr176:  sm->cs = 148; goto _again;
+	tr420:  sm->cs = 146; goto _again;
+	tr169:  sm->cs = 147; goto _again;
+	tr170:  sm->cs = 148; goto _again;
 	tr177:  sm->cs = 149; goto _again;
 	tr178:  sm->cs = 150; goto _again;
 	tr179:  sm->cs = 151; goto _again;
-	tr169:  sm->cs = 152; goto _again;
-	tr170:  sm->cs = 153; goto _again;
-	tr182:  sm->cs = 154; goto _again;
-	tr183:  sm->cs = 155; goto _again;
+	tr180:  sm->cs = 152; goto _again;
+	tr181:  sm->cs = 153; goto _again;
+	tr171:  sm->cs = 154; goto _again;
+	tr172:  sm->cs = 155; goto _again;
 	tr184:  sm->cs = 156; goto _again;
 	tr185:  sm->cs = 157; goto _again;
-	tr171:  sm->cs = 158; goto _again;
+	tr186:  sm->cs = 158; goto _again;
 	tr187:  sm->cs = 159; goto _again;
-	tr189:  sm->cs = 160; goto _again;
-	tr190:  sm->cs = 161; goto _again;
+	tr173:  sm->cs = 160; goto _again;
+	tr189:  sm->cs = 161; goto _again;
 	tr191:  sm->cs = 162; goto _again;
 	tr192:  sm->cs = 163; goto _again;
 	tr193:  sm->cs = 164; goto _again;
-	tr172:  sm->cs = 165; goto _again;
+	tr194:  sm->cs = 165; goto _again;
 	tr195:  sm->cs = 166; goto _again;
 	tr196:  sm->cs = 167; goto _again;
-	tr197:  sm->cs = 168; goto _again;
-	tr173:  sm->cs = 169; goto _again;
-	tr417:  sm->cs = 170; goto _again;
-	tr418:  sm->cs = 171; goto _again;
-	tr203:  sm->cs = 172; goto _again;
-	tr204:  sm->cs = 173; goto _again;
-	tr205:  sm->cs = 174; goto _again;
+	tr174:  sm->cs = 168; goto _again;
+	tr198:  sm->cs = 169; goto _again;
+	tr199:  sm->cs = 170; goto _again;
+	tr200:  sm->cs = 171; goto _again;
+	tr175:  sm->cs = 172; goto _again;
+	tr421:  sm->cs = 173; goto _again;
+	tr422:  sm->cs = 174; goto _again;
 	tr206:  sm->cs = 175; goto _again;
 	tr207:  sm->cs = 176; goto _again;
-	tr419:  sm->cs = 177; goto _again;
-	tr420:  sm->cs = 178; goto _again;
+	tr208:  sm->cs = 177; goto _again;
+	tr209:  sm->cs = 178; goto _again;
 	tr210:  sm->cs = 179; goto _again;
-	tr211:  sm->cs = 180; goto _again;
-	tr212:  sm->cs = 181; goto _again;
+	tr423:  sm->cs = 180; goto _again;
+	tr424:  sm->cs = 181; goto _again;
 	tr213:  sm->cs = 182; goto _again;
 	tr214:  sm->cs = 183; goto _again;
 	tr215:  sm->cs = 184; goto _again;
-	tr421:  sm->cs = 185; goto _again;
+	tr216:  sm->cs = 185; goto _again;
 	tr217:  sm->cs = 186; goto _again;
 	tr218:  sm->cs = 187; goto _again;
-	tr219:  sm->cs = 188; goto _again;
+	tr425:  sm->cs = 188; goto _again;
 	tr220:  sm->cs = 189; goto _again;
-	tr422:  sm->cs = 190; goto _again;
+	tr221:  sm->cs = 190; goto _again;
 	tr222:  sm->cs = 191; goto _again;
-	tr224:  sm->cs = 192; goto _again;
-	tr225:  sm->cs = 193; goto _again;
-	tr226:  sm->cs = 194; goto _again;
+	tr223:  sm->cs = 192; goto _again;
+	tr426:  sm->cs = 193; goto _again;
+	tr225:  sm->cs = 194; goto _again;
 	tr227:  sm->cs = 195; goto _again;
 	tr228:  sm->cs = 196; goto _again;
-	tr423:  sm->cs = 197; goto _again;
+	tr229:  sm->cs = 197; goto _again;
 	tr230:  sm->cs = 198; goto _again;
-	tr424:  sm->cs = 199; goto _again;
-	tr425:  sm->cs = 200; goto _again;
-	tr235:  sm->cs = 201; goto _again;
-	tr233:  sm->cs = 201; goto f7;
-	tr236:  sm->cs = 202; goto f4;
-	tr237:  sm->cs = 203; goto f4;
-	tr240:  sm->cs = 204; goto _again;
-	tr239:  sm->cs = 204; goto f3;
-	tr241:  sm->cs = 205; goto f5;
-	tr243:  sm->cs = 206; goto _again;
-	tr234:  sm->cs = 206; goto f7;
-	tr427:  sm->cs = 207; goto _again;
+	tr231:  sm->cs = 199; goto _again;
+	tr232:  sm->cs = 200; goto _again;
+	tr427:  sm->cs = 201; goto _again;
+	tr234:  sm->cs = 202; goto _again;
+	tr428:  sm->cs = 203; goto _again;
+	tr429:  sm->cs = 204; goto _again;
+	tr239:  sm->cs = 205; goto _again;
+	tr237:  sm->cs = 205; goto f7;
+	tr240:  sm->cs = 206; goto f4;
+	tr241:  sm->cs = 207; goto f4;
 	tr244:  sm->cs = 208; goto _again;
-	tr245:  sm->cs = 209; goto _again;
-	tr246:  sm->cs = 210; goto _again;
-	tr248:  sm->cs = 211; goto _again;
-	tr249:  sm->cs = 212; goto _again;
-	tr250:  sm->cs = 213; goto _again;
-	tr251:  sm->cs = 214; goto _again;
+	tr243:  sm->cs = 208; goto f3;
+	tr245:  sm->cs = 209; goto f5;
+	tr247:  sm->cs = 210; goto _again;
+	tr238:  sm->cs = 210; goto f7;
+	tr431:  sm->cs = 211; goto _again;
+	tr248:  sm->cs = 212; goto _again;
+	tr249:  sm->cs = 213; goto _again;
+	tr250:  sm->cs = 214; goto _again;
 	tr252:  sm->cs = 215; goto _again;
-	tr247:  sm->cs = 216; goto _again;
-	tr429:  sm->cs = 217; goto _again;
+	tr253:  sm->cs = 216; goto _again;
+	tr254:  sm->cs = 217; goto _again;
 	tr255:  sm->cs = 218; goto _again;
-	tr254:  sm->cs = 218; goto f7;
-	tr256:  sm->cs = 219; goto f4;
-	tr434:  sm->cs = 220; goto _again;
-	tr259:  sm->cs = 221; goto _again;
-	tr260:  sm->cs = 222; goto _again;
-	tr261:  sm->cs = 223; goto _again;
-	tr262:  sm->cs = 224; goto _again;
-	tr439:  sm->cs = 225; goto _again;
-	tr265:  sm->cs = 226; goto _again;
-	tr266:  sm->cs = 227; goto _again;
-	tr267:  sm->cs = 228; goto _again;
-	tr268:  sm->cs = 229; goto _again;
+	tr256:  sm->cs = 219; goto _again;
+	tr251:  sm->cs = 220; goto _again;
+	tr433:  sm->cs = 221; goto _again;
+	tr259:  sm->cs = 222; goto _again;
+	tr258:  sm->cs = 222; goto f7;
+	tr260:  sm->cs = 223; goto f4;
+	tr438:  sm->cs = 224; goto _again;
+	tr263:  sm->cs = 225; goto _again;
+	tr264:  sm->cs = 226; goto _again;
+	tr265:  sm->cs = 227; goto _again;
+	tr266:  sm->cs = 228; goto _again;
+	tr443:  sm->cs = 229; goto _again;
 	tr269:  sm->cs = 230; goto _again;
 	tr270:  sm->cs = 231; goto _again;
 	tr271:  sm->cs = 232; goto _again;
-	tr444:  sm->cs = 233; goto _again;
-	tr274:  sm->cs = 234; goto _again;
-	tr275:  sm->cs = 235; goto _again;
-	tr279:  sm->cs = 236; goto _again;
-	tr280:  sm->cs = 237; goto _again;
-	tr281:  sm->cs = 238; goto _again;
-	tr276:  sm->cs = 239; goto _again;
+	tr272:  sm->cs = 233; goto _again;
+	tr273:  sm->cs = 234; goto _again;
+	tr274:  sm->cs = 235; goto _again;
+	tr275:  sm->cs = 236; goto _again;
+	tr448:  sm->cs = 237; goto _again;
+	tr278:  sm->cs = 238; goto _again;
+	tr279:  sm->cs = 239; goto _again;
 	tr283:  sm->cs = 240; goto _again;
 	tr284:  sm->cs = 241; goto _again;
 	tr285:  sm->cs = 242; goto _again;
-	tr277:  sm->cs = 243; goto _again;
+	tr280:  sm->cs = 243; goto _again;
 	tr287:  sm->cs = 244; goto _again;
 	tr288:  sm->cs = 245; goto _again;
 	tr289:  sm->cs = 246; goto _again;
-	tr278:  sm->cs = 247; goto _again;
-	tr445:  sm->cs = 248; goto _again;
+	tr281:  sm->cs = 247; goto _again;
+	tr291:  sm->cs = 248; goto _again;
 	tr292:  sm->cs = 249; goto _again;
-	tr296:  sm->cs = 250; goto _again;
-	tr297:  sm->cs = 251; goto _again;
-	tr298:  sm->cs = 252; goto _again;
-	tr293:  sm->cs = 253; goto _again;
-	tr294:  sm->cs = 254; goto _again;
+	tr293:  sm->cs = 250; goto _again;
+	tr282:  sm->cs = 251; goto _again;
+	tr449:  sm->cs = 252; goto _again;
+	tr296:  sm->cs = 253; goto _again;
+	tr300:  sm->cs = 254; goto _again;
 	tr301:  sm->cs = 255; goto _again;
-	tr303:  sm->cs = 256; goto _again;
-	tr304:  sm->cs = 257; goto _again;
-	tr295:  sm->cs = 258; goto _again;
-	tr451:  sm->cs = 259; goto _again;
-	tr312:  sm->cs = 260; goto f4;
-	tr313:  sm->cs = 261; goto _again;
-	tr0:  sm->cs = 262; goto f0;
-	tr2:  sm->cs = 262; goto f2;
-	tr19:  sm->cs = 262; goto f6;
-	tr58:  sm->cs = 262; goto f8;
-	tr59:  sm->cs = 262; goto f9;
-	tr314:  sm->cs = 262; goto f61;
-	tr315:  sm->cs = 262; goto f62;
-	tr322:  sm->cs = 262; goto f65;
-	tr323:  sm->cs = 262; goto f66;
-	tr326:  sm->cs = 262; goto f67;
-	tr328:  sm->cs = 262; goto f68;
-	tr337:  sm->cs = 262; goto f69;
-	tr338:  sm->cs = 262; goto f70;
-	tr340:  sm->cs = 262; goto f71;
-	tr341:  sm->cs = 262; goto f72;
-	tr342:  sm->cs = 262; goto f73;
-	tr343:  sm->cs = 262; goto f74;
-	tr1:  sm->cs = 263; goto f1;
-	tr316:  sm->cs = 263; goto f63;
-	tr317:  sm->cs = 264; goto _again;
-	tr318:  sm->cs = 265; goto f17;
-	tr324:  sm->cs = 266; goto _again;
-	tr3:  sm->cs = 266; goto f3;
-	tr4:  sm->cs = 267; goto f3;
-	tr319:  sm->cs = 268; goto f64;
-	tr327:  sm->cs = 269; goto _again;
-	tr11:  sm->cs = 269; goto f5;
-	tr329:  sm->cs = 270; goto _again;
-	tr8:  sm->cs = 270; goto f4;
-	tr320:  sm->cs = 271; goto f64;
-	tr23:  sm->cs = 272; goto _again;
-	tr339:  sm->cs = 273; goto _again;
-	tr33:  sm->cs = 273; goto f4;
-	tr30:  sm->cs = 274; goto _again;
-	tr40:  sm->cs = 275; goto _again;
-	tr45:  sm->cs = 276; goto _again;
-	tr52:  sm->cs = 277; goto _again;
-	tr60:  sm->cs = 278; goto f10;
-	tr62:  sm->cs = 278; goto f12;
-	tr67:  sm->cs = 278; goto f13;
-	tr84:  sm->cs = 278; goto f15;
-	tr140:  sm->cs = 278; goto f18;
-	tr159:  sm->cs = 278; goto f19;
-	tr174:  sm->cs = 278; goto f20;
-	tr180:  sm->cs = 278; goto f21;
-	tr181:  sm->cs = 278; goto f22;
-	tr188:  sm->cs = 278; goto f23;
-	tr194:  sm->cs = 278; goto f24;
-	tr198:  sm->cs = 278; goto f25;
-	tr199:  sm->cs = 278; goto f26;
-	tr200:  sm->cs = 278; goto f27;
-	tr201:  sm->cs = 278; goto f28;
-	tr202:  sm->cs = 278; goto f29;
-	tr208:  sm->cs = 278; goto f30;
-	tr209:  sm->cs = 278; goto f31;
-	tr216:  sm->cs = 278; goto f32;
-	tr221:  sm->cs = 278; goto f33;
-	tr223:  sm->cs = 278; goto f34;
-	tr229:  sm->cs = 278; goto f35;
-	tr231:  sm->cs = 278; goto f36;
-	tr232:  sm->cs = 278; goto f37;
-	tr238:  sm->cs = 278; goto f38;
-	tr242:  sm->cs = 278; goto f39;
-	tr257:  sm->cs = 278; goto f41;
-	tr344:  sm->cs = 278; goto f75;
-	tr345:  sm->cs = 278; goto f76;
-	tr361:  sm->cs = 278; goto f79;
-	tr364:  sm->cs = 278; goto f80;
-	tr365:  sm->cs = 278; goto f81;
-	tr367:  sm->cs = 278; goto f82;
-	tr368:  sm->cs = 278; goto f83;
-	tr370:  sm->cs = 278; goto f84;
-	tr375:  sm->cs = 278; goto f86;
-	tr377:  sm->cs = 278; goto f87;
-	tr380:  sm->cs = 278; goto f89;
-	tr383:  sm->cs = 278; goto f90;
-	tr386:  sm->cs = 278; goto f91;
-	tr389:  sm->cs = 278; goto f92;
-	tr391:  sm->cs = 278; goto f93;
-	tr394:  sm->cs = 278; goto f94;
-	tr398:  sm->cs = 278; goto f95;
-	tr401:  sm->cs = 278; goto f96;
-	tr403:  sm->cs = 278; goto f97;
-	tr405:  sm->cs = 278; goto f98;
-	tr408:  sm->cs = 278; goto f99;
-	tr411:  sm->cs = 278; goto f100;
-	tr414:  sm->cs = 278; goto f101;
-	tr426:  sm->cs = 278; goto f102;
-	tr428:  sm->cs = 278; goto f103;
-	tr346:  sm->cs = 279; goto f77;
-	tr61:  sm->cs = 280; goto f11;
-	tr366:  sm->cs = 281; goto _again;
-	tr65:  sm->cs = 281; goto f3;
-	tr66:  sm->cs = 282; goto f3;
-	tr347:  sm->cs = 283; goto _again;
-	tr348:  sm->cs = 284; goto f78;
-	tr77:  sm->cs = 285; goto f14;
-	tr349:  sm->cs = 286; goto f78;
-	tr99:  sm->cs = 287; goto f16;
-	tr378:  sm->cs = 287; goto f88;
-	tr374:  sm->cs = 288; goto f85;
-	tr350:  sm->cs = 289; goto f64;
-	tr381:  sm->cs = 290; goto _again;
-	tr108:  sm->cs = 290; goto f7;
-	tr351:  sm->cs = 291; goto f64;
-	tr384:  sm->cs = 292; goto _again;
-	tr116:  sm->cs = 292; goto f7;
-	tr352:  sm->cs = 293; goto f64;
-	tr387:  sm->cs = 294; goto _again;
-	tr122:  sm->cs = 294; goto f7;
-	tr353:  sm->cs = 295; goto f64;
-	tr390:  sm->cs = 296; goto _again;
-	tr127:  sm->cs = 296; goto f5;
-	tr392:  sm->cs = 297; goto _again;
-	tr124:  sm->cs = 297; goto f4;
-	tr354:  sm->cs = 298; goto f64;
-	tr395:  sm->cs = 299; goto _again;
-	tr133:  sm->cs = 299; goto f7;
-	tr355:  sm->cs = 300; goto f64;
-	tr139:  sm->cs = 301; goto f17;
-	tr400:  sm->cs = 301; goto f64;
-	tr402:  sm->cs = 302; goto _again;
-	tr142:  sm->cs = 302; goto f3;
-	tr404:  sm->cs = 303; goto _again;
-	tr148:  sm->cs = 303; goto f7;
-	tr406:  sm->cs = 304; goto _again;
-	tr152:  sm->cs = 304; goto f7;
-	tr356:  sm->cs = 305; goto f64;
-	tr158:  sm->cs = 306; goto f17;
-	tr410:  sm->cs = 306; goto f64;
-	tr412:  sm->cs = 307; goto _again;
-	tr161:  sm->cs = 307; goto f3;
-	tr357:  sm->cs = 308; goto f64;
-	tr415:  sm->cs = 309; goto _again;
-	tr166:  sm->cs = 309; goto f7;
-	tr358:  sm->cs = 310; goto f64;
-	tr186:  sm->cs = 311; goto _again;
-	tr359:  sm->cs = 312; goto f78;
-	tr253:  sm->cs = 313; goto f40;
-	tr360:  sm->cs = 314; goto f64;
-	tr258:  sm->cs = 315; goto f42;
-	tr263:  sm->cs = 315; goto f43;
-	tr430:  sm->cs = 315; goto f104;
-	tr431:  sm->cs = 315; goto f105;
-	tr433:  sm->cs = 315; goto f106;
-	tr432:  sm->cs = 316; goto f64;
-	tr264:  sm->cs = 317; goto f44;
-	tr272:  sm->cs = 317; goto f45;
-	tr435:  sm->cs = 317; goto f107;
-	tr436:  sm->cs = 317; goto f108;
-	tr438:  sm->cs = 317; goto f109;
-	tr437:  sm->cs = 318; goto f64;
-	tr273:  sm->cs = 319; goto f46;
-	tr282:  sm->cs = 319; goto f47;
-	tr286:  sm->cs = 319; goto f48;
-	tr290:  sm->cs = 319; goto f49;
-	tr291:  sm->cs = 319; goto f50;
-	tr299:  sm->cs = 319; goto f51;
-	tr300:  sm->cs = 319; goto f52;
-	tr302:  sm->cs = 319; goto f53;
-	tr305:  sm->cs = 319; goto f54;
-	tr306:  sm->cs = 319; goto f55;
-	tr440:  sm->cs = 319; goto f110;
-	tr441:  sm->cs = 319; goto f111;
-	tr443:  sm->cs = 319; goto f112;
-	tr442:  sm->cs = 320; goto f64;
-	tr307:  sm->cs = 321; goto f56;
-	tr309:  sm->cs = 321; goto f58;
-	tr446:  sm->cs = 321; goto f113;
-	tr447:  sm->cs = 321; goto f114;
-	tr452:  sm->cs = 321; goto f116;
-	tr453:  sm->cs = 321; goto f117;
-	tr308:  sm->cs = 322; goto f57;
-	tr448:  sm->cs = 322; goto f115;
-	tr449:  sm->cs = 323; goto _again;
-	tr450:  sm->cs = 324; goto f17;
-	tr454:  sm->cs = 325; goto _again;
-	tr310:  sm->cs = 325; goto f3;
-	tr311:  sm->cs = 326; goto f3;
+	tr302:  sm->cs = 256; goto _again;
+	tr297:  sm->cs = 257; goto _again;
+	tr298:  sm->cs = 258; goto _again;
+	tr305:  sm->cs = 259; goto _again;
+	tr307:  sm->cs = 260; goto _again;
+	tr308:  sm->cs = 261; goto _again;
+	tr299:  sm->cs = 262; goto _again;
+	tr455:  sm->cs = 263; goto _again;
+	tr316:  sm->cs = 264; goto f4;
+	tr317:  sm->cs = 265; goto _again;
+	tr0:  sm->cs = 266; goto f0;
+	tr2:  sm->cs = 266; goto f2;
+	tr20:  sm->cs = 266; goto f6;
+	tr60:  sm->cs = 266; goto f8;
+	tr61:  sm->cs = 266; goto f9;
+	tr318:  sm->cs = 266; goto f61;
+	tr319:  sm->cs = 266; goto f62;
+	tr326:  sm->cs = 266; goto f65;
+	tr327:  sm->cs = 266; goto f66;
+	tr330:  sm->cs = 266; goto f67;
+	tr332:  sm->cs = 266; goto f68;
+	tr341:  sm->cs = 266; goto f69;
+	tr342:  sm->cs = 266; goto f70;
+	tr344:  sm->cs = 266; goto f71;
+	tr345:  sm->cs = 266; goto f72;
+	tr346:  sm->cs = 266; goto f73;
+	tr347:  sm->cs = 266; goto f74;
+	tr1:  sm->cs = 267; goto f1;
+	tr320:  sm->cs = 267; goto f63;
+	tr321:  sm->cs = 268; goto _again;
+	tr322:  sm->cs = 269; goto f17;
+	tr328:  sm->cs = 270; goto _again;
+	tr3:  sm->cs = 270; goto f3;
+	tr4:  sm->cs = 271; goto f3;
+	tr323:  sm->cs = 272; goto f64;
+	tr331:  sm->cs = 273; goto _again;
+	tr11:  sm->cs = 273; goto f5;
+	tr333:  sm->cs = 274; goto _again;
+	tr8:  sm->cs = 274; goto f4;
+	tr324:  sm->cs = 275; goto f64;
+	tr24:  sm->cs = 276; goto _again;
+	tr343:  sm->cs = 277; goto _again;
+	tr34:  sm->cs = 277; goto f4;
+	tr31:  sm->cs = 278; goto _again;
+	tr41:  sm->cs = 279; goto _again;
+	tr46:  sm->cs = 280; goto _again;
+	tr54:  sm->cs = 281; goto _again;
+	tr62:  sm->cs = 282; goto f10;
+	tr64:  sm->cs = 282; goto f12;
+	tr69:  sm->cs = 282; goto f13;
+	tr86:  sm->cs = 282; goto f15;
+	tr142:  sm->cs = 282; goto f18;
+	tr161:  sm->cs = 282; goto f19;
+	tr176:  sm->cs = 282; goto f20;
+	tr182:  sm->cs = 282; goto f21;
+	tr183:  sm->cs = 282; goto f22;
+	tr190:  sm->cs = 282; goto f23;
+	tr197:  sm->cs = 282; goto f24;
+	tr201:  sm->cs = 282; goto f25;
+	tr202:  sm->cs = 282; goto f26;
+	tr203:  sm->cs = 282; goto f27;
+	tr204:  sm->cs = 282; goto f28;
+	tr205:  sm->cs = 282; goto f29;
+	tr211:  sm->cs = 282; goto f30;
+	tr212:  sm->cs = 282; goto f31;
+	tr219:  sm->cs = 282; goto f32;
+	tr224:  sm->cs = 282; goto f33;
+	tr226:  sm->cs = 282; goto f34;
+	tr233:  sm->cs = 282; goto f35;
+	tr235:  sm->cs = 282; goto f36;
+	tr236:  sm->cs = 282; goto f37;
+	tr242:  sm->cs = 282; goto f38;
+	tr246:  sm->cs = 282; goto f39;
+	tr261:  sm->cs = 282; goto f41;
+	tr348:  sm->cs = 282; goto f75;
+	tr349:  sm->cs = 282; goto f76;
+	tr365:  sm->cs = 282; goto f79;
+	tr368:  sm->cs = 282; goto f80;
+	tr369:  sm->cs = 282; goto f81;
+	tr371:  sm->cs = 282; goto f82;
+	tr372:  sm->cs = 282; goto f83;
+	tr374:  sm->cs = 282; goto f84;
+	tr379:  sm->cs = 282; goto f86;
+	tr381:  sm->cs = 282; goto f87;
+	tr384:  sm->cs = 282; goto f89;
+	tr387:  sm->cs = 282; goto f90;
+	tr390:  sm->cs = 282; goto f91;
+	tr393:  sm->cs = 282; goto f92;
+	tr395:  sm->cs = 282; goto f93;
+	tr398:  sm->cs = 282; goto f94;
+	tr402:  sm->cs = 282; goto f95;
+	tr405:  sm->cs = 282; goto f96;
+	tr407:  sm->cs = 282; goto f97;
+	tr409:  sm->cs = 282; goto f98;
+	tr412:  sm->cs = 282; goto f99;
+	tr415:  sm->cs = 282; goto f100;
+	tr418:  sm->cs = 282; goto f101;
+	tr430:  sm->cs = 282; goto f102;
+	tr432:  sm->cs = 282; goto f103;
+	tr350:  sm->cs = 283; goto f77;
+	tr63:  sm->cs = 284; goto f11;
+	tr370:  sm->cs = 285; goto _again;
+	tr67:  sm->cs = 285; goto f3;
+	tr68:  sm->cs = 286; goto f3;
+	tr351:  sm->cs = 287; goto _again;
+	tr352:  sm->cs = 288; goto f78;
+	tr79:  sm->cs = 289; goto f14;
+	tr353:  sm->cs = 290; goto f78;
+	tr101:  sm->cs = 291; goto f16;
+	tr382:  sm->cs = 291; goto f88;
+	tr378:  sm->cs = 292; goto f85;
+	tr354:  sm->cs = 293; goto f64;
+	tr385:  sm->cs = 294; goto _again;
+	tr110:  sm->cs = 294; goto f7;
+	tr355:  sm->cs = 295; goto f64;
+	tr388:  sm->cs = 296; goto _again;
+	tr118:  sm->cs = 296; goto f7;
+	tr356:  sm->cs = 297; goto f64;
+	tr391:  sm->cs = 298; goto _again;
+	tr124:  sm->cs = 298; goto f7;
+	tr357:  sm->cs = 299; goto f64;
+	tr394:  sm->cs = 300; goto _again;
+	tr129:  sm->cs = 300; goto f5;
+	tr396:  sm->cs = 301; goto _again;
+	tr126:  sm->cs = 301; goto f4;
+	tr358:  sm->cs = 302; goto f64;
+	tr399:  sm->cs = 303; goto _again;
+	tr135:  sm->cs = 303; goto f7;
+	tr359:  sm->cs = 304; goto f64;
+	tr141:  sm->cs = 305; goto f17;
+	tr404:  sm->cs = 305; goto f64;
+	tr406:  sm->cs = 306; goto _again;
+	tr144:  sm->cs = 306; goto f3;
+	tr408:  sm->cs = 307; goto _again;
+	tr150:  sm->cs = 307; goto f7;
+	tr410:  sm->cs = 308; goto _again;
+	tr154:  sm->cs = 308; goto f7;
+	tr360:  sm->cs = 309; goto f64;
+	tr160:  sm->cs = 310; goto f17;
+	tr414:  sm->cs = 310; goto f64;
+	tr416:  sm->cs = 311; goto _again;
+	tr163:  sm->cs = 311; goto f3;
+	tr361:  sm->cs = 312; goto f64;
+	tr419:  sm->cs = 313; goto _again;
+	tr168:  sm->cs = 313; goto f7;
+	tr362:  sm->cs = 314; goto f64;
+	tr188:  sm->cs = 315; goto _again;
+	tr363:  sm->cs = 316; goto f78;
+	tr257:  sm->cs = 317; goto f40;
+	tr364:  sm->cs = 318; goto f64;
+	tr262:  sm->cs = 319; goto f42;
+	tr267:  sm->cs = 319; goto f43;
+	tr434:  sm->cs = 319; goto f104;
+	tr435:  sm->cs = 319; goto f105;
+	tr437:  sm->cs = 319; goto f106;
+	tr436:  sm->cs = 320; goto f64;
+	tr268:  sm->cs = 321; goto f44;
+	tr276:  sm->cs = 321; goto f45;
+	tr439:  sm->cs = 321; goto f107;
+	tr440:  sm->cs = 321; goto f108;
+	tr442:  sm->cs = 321; goto f109;
+	tr441:  sm->cs = 322; goto f64;
+	tr277:  sm->cs = 323; goto f46;
+	tr286:  sm->cs = 323; goto f47;
+	tr290:  sm->cs = 323; goto f48;
+	tr294:  sm->cs = 323; goto f49;
+	tr295:  sm->cs = 323; goto f50;
+	tr303:  sm->cs = 323; goto f51;
+	tr304:  sm->cs = 323; goto f52;
+	tr306:  sm->cs = 323; goto f53;
+	tr309:  sm->cs = 323; goto f54;
+	tr310:  sm->cs = 323; goto f55;
+	tr444:  sm->cs = 323; goto f110;
+	tr445:  sm->cs = 323; goto f111;
+	tr447:  sm->cs = 323; goto f112;
+	tr446:  sm->cs = 324; goto f64;
+	tr311:  sm->cs = 325; goto f56;
+	tr313:  sm->cs = 325; goto f58;
+	tr450:  sm->cs = 325; goto f113;
+	tr451:  sm->cs = 325; goto f114;
+	tr456:  sm->cs = 325; goto f116;
+	tr457:  sm->cs = 325; goto f117;
+	tr312:  sm->cs = 326; goto f57;
+	tr452:  sm->cs = 326; goto f115;
+	tr453:  sm->cs = 327; goto _again;
+	tr454:  sm->cs = 328; goto f17;
+	tr458:  sm->cs = 329; goto _again;
+	tr314:  sm->cs = 329; goto f3;
+	tr315:  sm->cs = 330; goto f3;
 
 f7:
 #line 98 "ext/dtext/dtext.rl"
@@ -2931,7 +2965,7 @@ f64:
 	{( sm->te) = ( sm->p)+1;}
 	goto _again;
 f41:
-#line 269 "ext/dtext/dtext.rl"
+#line 272 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     append(sm, true, "<a rel=\"nofollow\" href=\"/posts?tags=");
     append_segment_uri_escaped(sm, sm->a1, sm->a2 - 1);
@@ -2941,7 +2975,7 @@ f41:
   }}
 	goto _again;
 f38:
-#line 277 "ext/dtext/dtext.rl"
+#line 280 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     GString * segment = g_string_new_len(sm->a1, sm->a2 - sm->a1);
     GString * lowercase_segment = NULL;
@@ -2964,7 +2998,7 @@ f38:
   }}
 	goto _again;
 f39:
-#line 298 "ext/dtext/dtext.rl"
+#line 301 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     GString * segment = g_string_new_len(sm->a1, sm->a2 - sm->a1);
     GString * lowercase_segment = NULL;
@@ -2987,14 +3021,14 @@ f39:
   }}
 	goto _again;
 f29:
-#line 422 "ext/dtext/dtext.rl"
+#line 425 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_B);
     append(sm, true, "<strong>");
   }}
 	goto _again;
 f20:
-#line 427 "ext/dtext/dtext.rl"
+#line 430 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, INLINE_B)) {
       dstack_pop(sm);
@@ -3005,14 +3039,14 @@ f20:
   }}
 	goto _again;
 f31:
-#line 436 "ext/dtext/dtext.rl"
+#line 439 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_I);
     append(sm, true, "<em>");
   }}
 	goto _again;
 f22:
-#line 441 "ext/dtext/dtext.rl"
+#line 444 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, INLINE_I)) {
       dstack_pop(sm);
@@ -3023,14 +3057,14 @@ f22:
   }}
 	goto _again;
 f34:
-#line 450 "ext/dtext/dtext.rl"
+#line 453 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_S);
     append(sm, true, "<s>");
   }}
 	goto _again;
 f23:
-#line 455 "ext/dtext/dtext.rl"
+#line 458 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, INLINE_S)) {
       dstack_pop(sm);
@@ -3041,14 +3075,14 @@ f23:
   }}
 	goto _again;
 f37:
-#line 464 "ext/dtext/dtext.rl"
+#line 467 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_U);
     append(sm, true, "<u>");
   }}
 	goto _again;
 f28:
-#line 469 "ext/dtext/dtext.rl"
+#line 472 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, INLINE_U)) {
       dstack_pop(sm);
@@ -3059,14 +3093,14 @@ f28:
   }}
 	goto _again;
 f36:
-#line 478 "ext/dtext/dtext.rl"
+#line 481 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_TN);
     append(sm, true, "<span class=\"tn\">");
   }}
 	goto _again;
 f27:
-#line 483 "ext/dtext/dtext.rl"
+#line 486 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_close_before_block(sm);
 
@@ -3082,7 +3116,7 @@ f27:
   }}
 	goto _again;
 f33:
-#line 511 "ext/dtext/dtext.rl"
+#line 514 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline [quote]");
     dstack_close_before_block(sm);
@@ -3091,7 +3125,7 @@ f33:
   }}
 	goto _again;
 f35:
-#line 534 "ext/dtext/dtext.rl"
+#line 537 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline [spoiler]");
     g_debug("  push <span>");
@@ -3100,7 +3134,7 @@ f35:
   }}
 	goto _again;
 f24:
-#line 541 "ext/dtext/dtext.rl"
+#line 544 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline [/spoiler]");
     dstack_close_before_block(sm);
@@ -3123,7 +3157,7 @@ f24:
   }}
 	goto _again;
 f30:
-#line 562 "ext/dtext/dtext.rl"
+#line 565 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline [expand]");
     dstack_rewind(sm);
@@ -3132,7 +3166,7 @@ f30:
   }}
 	goto _again;
 f21:
-#line 569 "ext/dtext/dtext.rl"
+#line 572 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_close_before_block(sm);
 
@@ -3146,7 +3180,7 @@ f21:
   }}
 	goto _again;
 f32:
-#line 581 "ext/dtext/dtext.rl"
+#line 584 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &INLINE_NODTEXT);
     {
@@ -3160,11 +3194,11 @@ f32:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 317; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 321; goto _again;}}
   }}
 	goto _again;
 f26:
-#line 586 "ext/dtext/dtext.rl"
+#line 589 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_TH)) {
       dstack_pop(sm);
@@ -3176,7 +3210,7 @@ f26:
   }}
 	goto _again;
 f25:
-#line 596 "ext/dtext/dtext.rl"
+#line 599 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_TD)) {
       dstack_pop(sm);
@@ -3188,7 +3222,7 @@ f25:
   }}
 	goto _again;
 f76:
-#line 606 "ext/dtext/dtext.rl"
+#line 609 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline 0");
     g_debug("  return");
@@ -3198,14 +3232,14 @@ f76:
   }}
 	goto _again;
 f75:
-#line 642 "ext/dtext/dtext.rl"
+#line 645 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("inline char: %c", (*( sm->p)));
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f103:
-#line 350 "ext/dtext/dtext.rl"
+#line 353 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     if (is_boundary_c((*( sm->p)))) {
       sm->b = true;
@@ -3227,7 +3261,7 @@ f103:
   }}
 	goto _again;
 f93:
-#line 499 "ext/dtext/dtext.rl"
+#line 502 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     dstack_rewind(sm);
     {( sm->p) = (( sm->a1 - 1))-1;}
@@ -3235,7 +3269,7 @@ f93:
   }}
 	goto _again;
 f92:
-#line 505 "ext/dtext/dtext.rl"
+#line 508 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     dstack_rewind(sm);
     {( sm->p) = (( sm->a1 - 1))-1;}
@@ -3243,7 +3277,7 @@ f92:
   }}
 	goto _again;
 f102:
-#line 518 "ext/dtext/dtext.rl"
+#line 521 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("inline [/quote]");
     dstack_close_before_block(sm);
@@ -3261,7 +3295,7 @@ f102:
   }}
 	goto _again;
 f80:
-#line 614 "ext/dtext/dtext.rl"
+#line 617 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("inline newline2");
     g_debug("  return");
@@ -3275,7 +3309,7 @@ f80:
   }}
 	goto _again;
 f79:
-#line 626 "ext/dtext/dtext.rl"
+#line 629 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("inline newline");
 
@@ -3289,20 +3323,20 @@ f79:
   }}
 	goto _again;
 f82:
-#line 638 "ext/dtext/dtext.rl"
+#line 641 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append_c(sm, ' ');
   }}
 	goto _again;
 f83:
-#line 642 "ext/dtext/dtext.rl"
+#line 645 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("inline char: %c", (*( sm->p)));
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f19:
-#line 180 "ext/dtext/dtext.rl"
+#line 183 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     append(sm, true, "<a href=\"/forum_topics/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -3313,7 +3347,7 @@ f19:
   }}
 	goto _again;
 f18:
-#line 247 "ext/dtext/dtext.rl"
+#line 250 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     append(sm, true, "<a href=\"http://www.pixiv.net/member_illust.php?mode=medium&illust_id=");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -3324,7 +3358,7 @@ f18:
   }}
 	goto _again;
 f12:
-#line 626 "ext/dtext/dtext.rl"
+#line 629 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     g_debug("inline newline");
 
@@ -3338,7 +3372,7 @@ f12:
   }}
 	goto _again;
 f13:
-#line 642 "ext/dtext/dtext.rl"
+#line 645 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     g_debug("inline char: %c", (*( sm->p)));
     append_c_html_escaped(sm, (*( sm->p)));
@@ -3462,7 +3496,7 @@ f10:
 	}
 	goto _again;
 f43:
-#line 649 "ext/dtext/dtext.rl"
+#line 652 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_CODE)) {
       dstack_rewind(sm);
@@ -3473,32 +3507,32 @@ f43:
   }}
 	goto _again;
 f105:
-#line 658 "ext/dtext/dtext.rl"
+#line 661 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     ( sm->p)--;
     { sm->cs = ( ((int *)sm->stack->data))[--( sm->top)];goto _again;}
   }}
 	goto _again;
 f104:
-#line 663 "ext/dtext/dtext.rl"
+#line 666 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f106:
-#line 663 "ext/dtext/dtext.rl"
+#line 666 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f42:
-#line 663 "ext/dtext/dtext.rl"
+#line 666 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f45:
-#line 669 "ext/dtext/dtext.rl"
+#line 672 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_NODTEXT)) {
       dstack_pop(sm);
@@ -3513,39 +3547,39 @@ f45:
   }}
 	goto _again;
 f108:
-#line 682 "ext/dtext/dtext.rl"
+#line 685 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     ( sm->p)--;
     { sm->cs = ( ((int *)sm->stack->data))[--( sm->top)];goto _again;}
   }}
 	goto _again;
 f107:
-#line 687 "ext/dtext/dtext.rl"
+#line 690 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f109:
-#line 687 "ext/dtext/dtext.rl"
+#line 690 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f44:
-#line 687 "ext/dtext/dtext.rl"
+#line 690 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     append_c_html_escaped(sm, (*( sm->p)));
   }}
 	goto _again;
 f54:
-#line 693 "ext/dtext/dtext.rl"
+#line 696 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_THEAD);
     append_block(sm, "<thead>");
   }}
 	goto _again;
 f49:
-#line 698 "ext/dtext/dtext.rl"
+#line 701 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_THEAD)) {
       dstack_pop(sm);
@@ -3556,14 +3590,14 @@ f49:
   }}
 	goto _again;
 f51:
-#line 707 "ext/dtext/dtext.rl"
+#line 710 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_TBODY);
     append_block(sm, "<tbody>");
   }}
 	goto _again;
 f48:
-#line 712 "ext/dtext/dtext.rl"
+#line 715 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_TBODY)) {
       dstack_pop(sm);
@@ -3574,7 +3608,7 @@ f48:
   }}
 	goto _again;
 f53:
-#line 721 "ext/dtext/dtext.rl"
+#line 724 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_TH);
     append_block(sm, "<th>");
@@ -3589,18 +3623,18 @@ f53:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f55:
-#line 727 "ext/dtext/dtext.rl"
+#line 730 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_TR);
     append_block(sm, "<tr>");
   }}
 	goto _again;
 f50:
-#line 732 "ext/dtext/dtext.rl"
+#line 735 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_TR)) {
       dstack_pop(sm);
@@ -3611,7 +3645,7 @@ f50:
   }}
 	goto _again;
 f52:
-#line 741 "ext/dtext/dtext.rl"
+#line 744 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_TD);
     append_block(sm, "<td>");
@@ -3626,11 +3660,11 @@ f52:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f47:
-#line 747 "ext/dtext/dtext.rl"
+#line 750 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     if (dstack_check(sm, BLOCK_TABLE)) {
       dstack_pop(sm);
@@ -3642,26 +3676,26 @@ f47:
   }}
 	goto _again;
 f111:
-#line 757 "ext/dtext/dtext.rl"
+#line 760 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     ( sm->p)--;
     { sm->cs = ( ((int *)sm->stack->data))[--( sm->top)];goto _again;}
   }}
 	goto _again;
 f110:
-#line 762 "ext/dtext/dtext.rl"
+#line 765 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;}
 	goto _again;
 f112:
-#line 762 "ext/dtext/dtext.rl"
+#line 765 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;}
 	goto _again;
 f46:
-#line 762 "ext/dtext/dtext.rl"
+#line 765 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}}
 	goto _again;
 f114:
-#line 805 "ext/dtext/dtext.rl"
+#line 808 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_close_list(sm);
     {( sm->p) = (( sm->ts))-1;}
@@ -3669,7 +3703,7 @@ f114:
   }}
 	goto _again;
 f113:
-#line 813 "ext/dtext/dtext.rl"
+#line 816 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_rewind(sm);
     ( sm->p)--;
@@ -3677,7 +3711,7 @@ f113:
   }}
 	goto _again;
 f116:
-#line 813 "ext/dtext/dtext.rl"
+#line 816 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     dstack_rewind(sm);
     ( sm->p)--;
@@ -3685,7 +3719,7 @@ f116:
   }}
 	goto _again;
 f58:
-#line 813 "ext/dtext/dtext.rl"
+#line 816 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     dstack_rewind(sm);
     ( sm->p)--;
@@ -3709,7 +3743,7 @@ f56:
 	}
 	goto _again;
 f6:
-#line 945 "ext/dtext/dtext.rl"
+#line 948 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("block [/spoiler]");
     dstack_close_before_block(sm);
@@ -3720,7 +3754,7 @@ f6:
   }}
 	goto _again;
 f8:
-#line 992 "ext/dtext/dtext.rl"
+#line 995 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_close_before_block(sm);
     dstack_push(sm, &BLOCK_TABLE);
@@ -3736,11 +3770,11 @@ f8:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 319; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 323; goto _again;}}
   }}
 	goto _again;
 f9:
-#line 999 "ext/dtext/dtext.rl"
+#line 1002 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     dstack_push(sm, &BLOCK_TN);
     append_block(sm, "<p class=\"tn\">");
@@ -3755,11 +3789,11 @@ f9:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f62:
-#line 1015 "ext/dtext/dtext.rl"
+#line 1018 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("block 0");
     g_debug("  close dstack");
@@ -3767,7 +3801,7 @@ f62:
   }}
 	goto _again;
 f61:
-#line 1038 "ext/dtext/dtext.rl"
+#line 1041 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     g_debug("block char: %c", (*( sm->p)));
     ( sm->p)--;
@@ -3790,11 +3824,11 @@ f61:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f67:
-#line 821 "ext/dtext/dtext.rl"
+#line 824 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     char header = *sm->a1;
     GString * id_name = g_string_new_len(sm->b1, sm->b2 - sm->b1);
@@ -3864,11 +3898,11 @@ f67:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f68:
-#line 882 "ext/dtext/dtext.rl"
+#line 885 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     char header = *sm->a1;
 
@@ -3922,11 +3956,11 @@ f68:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f73:
-#line 927 "ext/dtext/dtext.rl"
+#line 930 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [quote]");
     g_debug("  push quote");
@@ -3937,7 +3971,7 @@ f73:
   }}
 	goto _again;
 f74:
-#line 936 "ext/dtext/dtext.rl"
+#line 939 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [spoiler]");
     g_debug("  push spoiler");
@@ -3948,7 +3982,7 @@ f74:
   }}
 	goto _again;
 f69:
-#line 954 "ext/dtext/dtext.rl"
+#line 957 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [code]");
     dstack_close_before_block(sm);
@@ -3965,11 +3999,11 @@ f69:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 315; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 319; goto _again;}}
   }}
 	goto _again;
 f71:
-#line 962 "ext/dtext/dtext.rl"
+#line 965 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [expand]");
     dstack_close_before_block(sm);
@@ -3980,7 +4014,7 @@ f71:
   }}
 	goto _again;
 f70:
-#line 971 "ext/dtext/dtext.rl"
+#line 974 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [expand=]");
     dstack_close_before_block(sm);
@@ -3994,7 +4028,7 @@ f70:
   }}
 	goto _again;
 f72:
-#line 983 "ext/dtext/dtext.rl"
+#line 986 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block [nodtext]");
     dstack_close_before_block(sm);
@@ -4012,11 +4046,11 @@ f72:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 317; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 321; goto _again;}}
   }}
 	goto _again;
 f65:
-#line 1038 "ext/dtext/dtext.rl"
+#line 1041 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block char: %c", (*( sm->p)));
     ( sm->p)--;
@@ -4039,11 +4073,11 @@ f65:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f2:
-#line 1038 "ext/dtext/dtext.rl"
+#line 1041 "ext/dtext/dtext.rl"
 	{{( sm->p) = ((( sm->te)))-1;}{
     g_debug("block char: %c", (*( sm->p)));
     ( sm->p)--;
@@ -4066,7 +4100,7 @@ f2:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f0:
@@ -4099,7 +4133,7 @@ f98:
 	{
   sm->a2 = sm->p;
 }
-#line 162 "ext/dtext/dtext.rl"
+#line 165 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/posts/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4114,7 +4148,7 @@ f91:
 	{
   sm->a2 = sm->p;
 }
-#line 171 "ext/dtext/dtext.rl"
+#line 174 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/forum_posts/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4129,7 +4163,7 @@ f99:
 	{
   sm->a2 = sm->p;
 }
-#line 180 "ext/dtext/dtext.rl"
+#line 183 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/forum_topics/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4144,7 +4178,7 @@ f90:
 	{
   sm->a2 = sm->p;
 }
-#line 202 "ext/dtext/dtext.rl"
+#line 205 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/comments/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4159,7 +4193,7 @@ f97:
 	{
   sm->a2 = sm->p;
 }
-#line 211 "ext/dtext/dtext.rl"
+#line 214 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/pools/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4174,7 +4208,7 @@ f101:
 	{
   sm->a2 = sm->p;
 }
-#line 220 "ext/dtext/dtext.rl"
+#line 223 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/users/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4189,7 +4223,7 @@ f89:
 	{
   sm->a2 = sm->p;
 }
-#line 229 "ext/dtext/dtext.rl"
+#line 232 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/artists/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4204,7 +4238,7 @@ f94:
 	{
   sm->a2 = sm->p;
 }
-#line 238 "ext/dtext/dtext.rl"
+#line 241 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"https://github.com/r888888888/danbooru/issues/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4219,7 +4253,7 @@ f95:
 	{
   sm->a2 = sm->p;
 }
-#line 247 "ext/dtext/dtext.rl"
+#line 250 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"http://www.pixiv.net/member_illust.php?mode=medium&illust_id=");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4234,7 +4268,7 @@ f87:
 	{
   sm->a2 = sm->p;
 }
-#line 375 "ext/dtext/dtext.rl"
+#line 378 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     if (!sm->f_mentions || (sm->a1 > sm->pb && sm->a1 - 1 > sm->pb && sm->a1[-2] != ' ' && sm->a1[-2] != '\r' && sm->a1[-2] != '\n')) {
       // handle emails
@@ -4389,7 +4423,7 @@ f15:
 	{
   sm->b2 = sm->p;
 }
-#line 342 "ext/dtext/dtext.rl"
+#line 345 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p)+1;{
     append(sm, true, "<a href=\"");
     append_segment_html_escaped(sm, sm->b1, sm->b2 - 1);
@@ -4403,7 +4437,7 @@ f100:
 	{
   sm->b2 = sm->p;
 }
-#line 189 "ext/dtext/dtext.rl"
+#line 192 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"/forum_topics/");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4422,7 +4456,7 @@ f96:
 	{
   sm->b2 = sm->p;
 }
-#line 256 "ext/dtext/dtext.rl"
+#line 259 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     append(sm, true, "<a href=\"http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=");
     append_segment(sm, true, sm->a1, sm->a2 - 1);
@@ -4441,7 +4475,7 @@ f84:
 	{
   sm->b2 = sm->p;
 }
-#line 319 "ext/dtext/dtext.rl"
+#line 322 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     if (is_boundary_c((*( sm->p)))) {
       sm->d = 2;
@@ -4470,7 +4504,7 @@ f81:
 	{
   sm->b2 = sm->p;
 }
-#line 403 "ext/dtext/dtext.rl"
+#line 406 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("inline list");
 
@@ -4487,7 +4521,7 @@ f81:
 
     g_debug("  next list");
     {( sm->p) = (( sm->ts + 1))-1;}
-     sm->cs = 321;
+     sm->cs = 325;
   }}
 	goto _again;
 f117:
@@ -4495,7 +4529,7 @@ f117:
 	{
   sm->b2 = sm->p;
 }
-#line 766 "ext/dtext/dtext.rl"
+#line 769 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     int prev_nest = sm->list_nest;
     append_closing_p_if(sm);
@@ -4542,7 +4576,7 @@ f117:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 278; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 282; goto _again;}}
   }}
 	goto _again;
 f66:
@@ -4550,7 +4584,7 @@ f66:
 	{
   sm->b2 = sm->p;
 }
-#line 1005 "ext/dtext/dtext.rl"
+#line 1008 "ext/dtext/dtext.rl"
 	{( sm->te) = ( sm->p);( sm->p)--;{
     g_debug("block list");
     g_debug("  call list");
@@ -4569,7 +4603,7 @@ f66:
   if (sm->top >= len) {
     sm->stack = g_array_set_size(sm->stack, len + 16);
   }
-{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 321; goto _again;}}
+{( ((int *)sm->stack->data))[( sm->top)++] =  sm->cs;  sm->cs = 325; goto _again;}}
   }}
 	goto _again;
 f17:
@@ -4583,67 +4617,67 @@ f17:
 f14:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 319 "ext/dtext/dtext.rl"
+#line 322 "ext/dtext/dtext.rl"
 	{( sm->act) = 15;}
 	goto _again;
 f40:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 350 "ext/dtext/dtext.rl"
+#line 353 "ext/dtext/dtext.rl"
 	{( sm->act) = 17;}
 	goto _again;
 f88:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 371 "ext/dtext/dtext.rl"
+#line 374 "ext/dtext/dtext.rl"
 	{( sm->act) = 18;}
 	goto _again;
 f16:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 375 "ext/dtext/dtext.rl"
+#line 378 "ext/dtext/dtext.rl"
 	{( sm->act) = 19;}
 	goto _again;
 f11:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 614 "ext/dtext/dtext.rl"
+#line 617 "ext/dtext/dtext.rl"
 	{( sm->act) = 43;}
 	goto _again;
 f77:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 626 "ext/dtext/dtext.rl"
+#line 629 "ext/dtext/dtext.rl"
 	{( sm->act) = 44;}
 	goto _again;
 f78:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 642 "ext/dtext/dtext.rl"
+#line 645 "ext/dtext/dtext.rl"
 	{( sm->act) = 46;}
 	goto _again;
 f57:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 805 "ext/dtext/dtext.rl"
+#line 808 "ext/dtext/dtext.rl"
 	{( sm->act) = 65;}
 	goto _again;
 f115:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 811 "ext/dtext/dtext.rl"
+#line 814 "ext/dtext/dtext.rl"
 	{( sm->act) = 66;}
 	goto _again;
 f1:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 1021 "ext/dtext/dtext.rl"
+#line 1024 "ext/dtext/dtext.rl"
 	{( sm->act) = 81;}
 	goto _again;
 f63:
 #line 1 "NONE"
 	{( sm->te) = ( sm->p)+1;}
-#line 1034 "ext/dtext/dtext.rl"
+#line 1037 "ext/dtext/dtext.rl"
 	{( sm->act) = 82;}
 	goto _again;
 f85:
@@ -4653,7 +4687,7 @@ f85:
 	{
   sm->a1 = sm->p;
 }
-#line 375 "ext/dtext/dtext.rl"
+#line 378 "ext/dtext/dtext.rl"
 	{( sm->act) = 19;}
 	goto _again;
 
@@ -4663,7 +4697,7 @@ _again:
 #line 1 "NONE"
 	{( sm->ts) = 0;}
 	break;
-#line 4667 "ext/dtext/dtext.c"
+#line 4701 "ext/dtext/dtext.c"
 	}
 
 	if ( ++( sm->p) != ( sm->pe) )
@@ -4672,21 +4706,21 @@ _again:
 	if ( ( sm->p) == ( sm->eof) )
 	{
 	switch (  sm->cs ) {
-	case 263: goto tr0;
+	case 267: goto tr0;
 	case 0: goto tr0;
-	case 264: goto tr322;
-	case 265: goto tr322;
+	case 268: goto tr326;
+	case 269: goto tr326;
 	case 1: goto tr2;
-	case 266: goto tr323;
-	case 267: goto tr323;
+	case 270: goto tr327;
+	case 271: goto tr327;
 	case 2: goto tr2;
-	case 268: goto tr322;
+	case 272: goto tr326;
 	case 3: goto tr2;
 	case 4: goto tr2;
 	case 5: goto tr2;
-	case 269: goto tr326;
-	case 270: goto tr328;
-	case 271: goto tr322;
+	case 273: goto tr330;
+	case 274: goto tr332;
+	case 275: goto tr326;
 	case 6: goto tr2;
 	case 7: goto tr2;
 	case 8: goto tr2;
@@ -4699,8 +4733,8 @@ _again:
 	case 15: goto tr2;
 	case 16: goto tr2;
 	case 17: goto tr2;
-	case 272: goto tr337;
 	case 18: goto tr2;
+	case 276: goto tr341;
 	case 19: goto tr2;
 	case 20: goto tr2;
 	case 21: goto tr2;
@@ -4708,297 +4742,301 @@ _again:
 	case 23: goto tr2;
 	case 24: goto tr2;
 	case 25: goto tr2;
-	case 273: goto tr338;
-	case 274: goto tr340;
 	case 26: goto tr2;
+	case 277: goto tr342;
+	case 278: goto tr344;
 	case 27: goto tr2;
 	case 28: goto tr2;
 	case 29: goto tr2;
 	case 30: goto tr2;
 	case 31: goto tr2;
 	case 32: goto tr2;
-	case 275: goto tr341;
 	case 33: goto tr2;
+	case 279: goto tr345;
 	case 34: goto tr2;
 	case 35: goto tr2;
 	case 36: goto tr2;
 	case 37: goto tr2;
-	case 276: goto tr342;
 	case 38: goto tr2;
+	case 280: goto tr346;
 	case 39: goto tr2;
 	case 40: goto tr2;
 	case 41: goto tr2;
 	case 42: goto tr2;
 	case 43: goto tr2;
 	case 44: goto tr2;
-	case 277: goto tr343;
 	case 45: goto tr2;
 	case 46: goto tr2;
+	case 281: goto tr347;
 	case 47: goto tr2;
 	case 48: goto tr2;
 	case 49: goto tr2;
 	case 50: goto tr2;
-	case 279: goto tr361;
-	case 280: goto tr364;
-	case 51: goto tr60;
-	case 52: goto tr62;
-	case 53: goto tr62;
-	case 281: goto tr365;
-	case 282: goto tr365;
-	case 283: goto tr367;
+	case 51: goto tr2;
+	case 52: goto tr2;
+	case 283: goto tr365;
 	case 284: goto tr368;
-	case 54: goto tr67;
-	case 55: goto tr67;
-	case 56: goto tr67;
-	case 57: goto tr67;
-	case 58: goto tr60;
-	case 285: goto tr370;
-	case 59: goto tr60;
-	case 60: goto tr60;
-	case 61: goto tr67;
-	case 62: goto tr67;
-	case 63: goto tr67;
-	case 64: goto tr67;
-	case 65: goto tr67;
-	case 66: goto tr67;
-	case 67: goto tr67;
-	case 68: goto tr67;
-	case 69: goto tr67;
-	case 70: goto tr67;
-	case 71: goto tr67;
-	case 72: goto tr67;
-	case 73: goto tr67;
-	case 74: goto tr67;
-	case 75: goto tr67;
-	case 76: goto tr67;
-	case 77: goto tr67;
-	case 78: goto tr67;
-	case 79: goto tr67;
-	case 80: goto tr67;
-	case 286: goto tr368;
-	case 81: goto tr60;
-	case 287: goto tr375;
-	case 82: goto tr60;
-	case 83: goto tr60;
-	case 288: goto tr377;
-	case 289: goto tr368;
-	case 84: goto tr67;
-	case 85: goto tr67;
-	case 86: goto tr67;
-	case 87: goto tr67;
-	case 88: goto tr67;
-	case 89: goto tr67;
-	case 90: goto tr67;
-	case 290: goto tr380;
-	case 291: goto tr368;
-	case 91: goto tr67;
-	case 92: goto tr67;
-	case 93: goto tr67;
-	case 94: goto tr67;
-	case 95: goto tr67;
-	case 96: goto tr67;
-	case 97: goto tr67;
-	case 98: goto tr67;
-	case 292: goto tr383;
-	case 293: goto tr368;
-	case 99: goto tr67;
-	case 100: goto tr67;
-	case 101: goto tr67;
-	case 102: goto tr67;
-	case 103: goto tr67;
-	case 104: goto tr67;
-	case 294: goto tr386;
-	case 295: goto tr368;
-	case 105: goto tr67;
-	case 106: goto tr67;
-	case 107: goto tr67;
-	case 296: goto tr389;
-	case 297: goto tr391;
-	case 298: goto tr368;
-	case 108: goto tr67;
-	case 109: goto tr67;
-	case 110: goto tr67;
-	case 111: goto tr67;
-	case 112: goto tr67;
-	case 113: goto tr67;
-	case 299: goto tr394;
-	case 300: goto tr368;
-	case 114: goto tr67;
-	case 115: goto tr67;
-	case 116: goto tr67;
-	case 117: goto tr67;
-	case 118: goto tr67;
-	case 119: goto tr67;
-	case 301: goto tr398;
-	case 120: goto tr140;
-	case 121: goto tr140;
-	case 302: goto tr401;
-	case 122: goto tr67;
-	case 123: goto tr67;
-	case 124: goto tr67;
-	case 125: goto tr67;
-	case 126: goto tr67;
-	case 303: goto tr403;
-	case 127: goto tr67;
-	case 128: goto tr67;
-	case 129: goto tr67;
-	case 130: goto tr67;
-	case 304: goto tr405;
-	case 305: goto tr368;
-	case 131: goto tr67;
-	case 132: goto tr67;
-	case 133: goto tr67;
-	case 134: goto tr67;
-	case 135: goto tr67;
-	case 136: goto tr67;
-	case 306: goto tr408;
-	case 137: goto tr159;
-	case 138: goto tr159;
-	case 307: goto tr411;
-	case 308: goto tr368;
-	case 139: goto tr67;
-	case 140: goto tr67;
-	case 141: goto tr67;
-	case 142: goto tr67;
-	case 143: goto tr67;
-	case 309: goto tr414;
-	case 310: goto tr368;
-	case 144: goto tr67;
-	case 145: goto tr67;
-	case 146: goto tr67;
-	case 147: goto tr67;
-	case 148: goto tr67;
-	case 149: goto tr67;
-	case 150: goto tr67;
-	case 151: goto tr67;
-	case 152: goto tr67;
-	case 153: goto tr67;
-	case 154: goto tr67;
-	case 155: goto tr67;
-	case 156: goto tr67;
-	case 157: goto tr67;
-	case 311: goto tr426;
-	case 158: goto tr67;
-	case 159: goto tr67;
-	case 160: goto tr67;
-	case 161: goto tr67;
-	case 162: goto tr67;
-	case 163: goto tr67;
-	case 164: goto tr67;
-	case 165: goto tr67;
-	case 166: goto tr67;
-	case 167: goto tr67;
-	case 168: goto tr67;
-	case 169: goto tr67;
-	case 170: goto tr67;
-	case 171: goto tr67;
-	case 172: goto tr67;
-	case 173: goto tr67;
-	case 174: goto tr67;
-	case 175: goto tr67;
-	case 176: goto tr67;
-	case 177: goto tr67;
-	case 178: goto tr67;
-	case 179: goto tr67;
-	case 180: goto tr67;
-	case 181: goto tr67;
-	case 182: goto tr67;
-	case 183: goto tr67;
-	case 184: goto tr67;
-	case 185: goto tr67;
-	case 186: goto tr67;
-	case 187: goto tr67;
-	case 188: goto tr67;
-	case 189: goto tr67;
-	case 190: goto tr67;
-	case 191: goto tr67;
-	case 192: goto tr67;
-	case 193: goto tr67;
-	case 194: goto tr67;
-	case 195: goto tr67;
-	case 196: goto tr67;
-	case 197: goto tr67;
-	case 198: goto tr67;
-	case 199: goto tr67;
-	case 200: goto tr67;
-	case 201: goto tr67;
-	case 202: goto tr67;
-	case 203: goto tr67;
-	case 204: goto tr67;
-	case 205: goto tr67;
-	case 206: goto tr67;
-	case 312: goto tr368;
-	case 207: goto tr67;
-	case 208: goto tr67;
-	case 209: goto tr67;
-	case 210: goto tr67;
-	case 211: goto tr67;
-	case 212: goto tr67;
-	case 213: goto tr60;
-	case 313: goto tr428;
-	case 214: goto tr60;
-	case 215: goto tr60;
-	case 216: goto tr67;
-	case 314: goto tr368;
-	case 217: goto tr67;
-	case 218: goto tr67;
-	case 219: goto tr67;
-	case 316: goto tr433;
-	case 220: goto tr258;
-	case 221: goto tr258;
-	case 222: goto tr258;
-	case 223: goto tr258;
-	case 224: goto tr258;
-	case 318: goto tr438;
-	case 225: goto tr264;
-	case 226: goto tr264;
-	case 227: goto tr264;
-	case 228: goto tr264;
-	case 229: goto tr264;
-	case 230: goto tr264;
-	case 231: goto tr264;
-	case 232: goto tr264;
-	case 320: goto tr443;
-	case 233: goto tr273;
-	case 234: goto tr273;
-	case 235: goto tr273;
-	case 236: goto tr273;
-	case 237: goto tr273;
-	case 238: goto tr273;
-	case 239: goto tr273;
-	case 240: goto tr273;
-	case 241: goto tr273;
-	case 242: goto tr273;
-	case 243: goto tr273;
-	case 244: goto tr273;
-	case 245: goto tr273;
-	case 246: goto tr273;
-	case 247: goto tr273;
-	case 248: goto tr273;
-	case 249: goto tr273;
-	case 250: goto tr273;
-	case 251: goto tr273;
-	case 252: goto tr273;
-	case 253: goto tr273;
-	case 254: goto tr273;
-	case 255: goto tr273;
-	case 256: goto tr273;
-	case 257: goto tr273;
-	case 258: goto tr273;
-	case 322: goto tr307;
-	case 259: goto tr307;
-	case 323: goto tr452;
-	case 324: goto tr452;
-	case 260: goto tr309;
-	case 325: goto tr453;
-	case 326: goto tr453;
-	case 261: goto tr309;
+	case 53: goto tr62;
+	case 54: goto tr64;
+	case 55: goto tr64;
+	case 285: goto tr369;
+	case 286: goto tr369;
+	case 287: goto tr371;
+	case 288: goto tr372;
+	case 56: goto tr69;
+	case 57: goto tr69;
+	case 58: goto tr69;
+	case 59: goto tr69;
+	case 60: goto tr62;
+	case 289: goto tr374;
+	case 61: goto tr62;
+	case 62: goto tr62;
+	case 63: goto tr69;
+	case 64: goto tr69;
+	case 65: goto tr69;
+	case 66: goto tr69;
+	case 67: goto tr69;
+	case 68: goto tr69;
+	case 69: goto tr69;
+	case 70: goto tr69;
+	case 71: goto tr69;
+	case 72: goto tr69;
+	case 73: goto tr69;
+	case 74: goto tr69;
+	case 75: goto tr69;
+	case 76: goto tr69;
+	case 77: goto tr69;
+	case 78: goto tr69;
+	case 79: goto tr69;
+	case 80: goto tr69;
+	case 81: goto tr69;
+	case 82: goto tr69;
+	case 290: goto tr372;
+	case 83: goto tr62;
+	case 291: goto tr379;
+	case 84: goto tr62;
+	case 85: goto tr62;
+	case 292: goto tr381;
+	case 293: goto tr372;
+	case 86: goto tr69;
+	case 87: goto tr69;
+	case 88: goto tr69;
+	case 89: goto tr69;
+	case 90: goto tr69;
+	case 91: goto tr69;
+	case 92: goto tr69;
+	case 294: goto tr384;
+	case 295: goto tr372;
+	case 93: goto tr69;
+	case 94: goto tr69;
+	case 95: goto tr69;
+	case 96: goto tr69;
+	case 97: goto tr69;
+	case 98: goto tr69;
+	case 99: goto tr69;
+	case 100: goto tr69;
+	case 296: goto tr387;
+	case 297: goto tr372;
+	case 101: goto tr69;
+	case 102: goto tr69;
+	case 103: goto tr69;
+	case 104: goto tr69;
+	case 105: goto tr69;
+	case 106: goto tr69;
+	case 298: goto tr390;
+	case 299: goto tr372;
+	case 107: goto tr69;
+	case 108: goto tr69;
+	case 109: goto tr69;
+	case 300: goto tr393;
+	case 301: goto tr395;
+	case 302: goto tr372;
+	case 110: goto tr69;
+	case 111: goto tr69;
+	case 112: goto tr69;
+	case 113: goto tr69;
+	case 114: goto tr69;
+	case 115: goto tr69;
+	case 303: goto tr398;
+	case 304: goto tr372;
+	case 116: goto tr69;
+	case 117: goto tr69;
+	case 118: goto tr69;
+	case 119: goto tr69;
+	case 120: goto tr69;
+	case 121: goto tr69;
+	case 305: goto tr402;
+	case 122: goto tr142;
+	case 123: goto tr142;
+	case 306: goto tr405;
+	case 124: goto tr69;
+	case 125: goto tr69;
+	case 126: goto tr69;
+	case 127: goto tr69;
+	case 128: goto tr69;
+	case 307: goto tr407;
+	case 129: goto tr69;
+	case 130: goto tr69;
+	case 131: goto tr69;
+	case 132: goto tr69;
+	case 308: goto tr409;
+	case 309: goto tr372;
+	case 133: goto tr69;
+	case 134: goto tr69;
+	case 135: goto tr69;
+	case 136: goto tr69;
+	case 137: goto tr69;
+	case 138: goto tr69;
+	case 310: goto tr412;
+	case 139: goto tr161;
+	case 140: goto tr161;
+	case 311: goto tr415;
+	case 312: goto tr372;
+	case 141: goto tr69;
+	case 142: goto tr69;
+	case 143: goto tr69;
+	case 144: goto tr69;
+	case 145: goto tr69;
+	case 313: goto tr418;
+	case 314: goto tr372;
+	case 146: goto tr69;
+	case 147: goto tr69;
+	case 148: goto tr69;
+	case 149: goto tr69;
+	case 150: goto tr69;
+	case 151: goto tr69;
+	case 152: goto tr69;
+	case 153: goto tr69;
+	case 154: goto tr69;
+	case 155: goto tr69;
+	case 156: goto tr69;
+	case 157: goto tr69;
+	case 158: goto tr69;
+	case 159: goto tr69;
+	case 315: goto tr430;
+	case 160: goto tr69;
+	case 161: goto tr69;
+	case 162: goto tr69;
+	case 163: goto tr69;
+	case 164: goto tr69;
+	case 165: goto tr69;
+	case 166: goto tr69;
+	case 167: goto tr69;
+	case 168: goto tr69;
+	case 169: goto tr69;
+	case 170: goto tr69;
+	case 171: goto tr69;
+	case 172: goto tr69;
+	case 173: goto tr69;
+	case 174: goto tr69;
+	case 175: goto tr69;
+	case 176: goto tr69;
+	case 177: goto tr69;
+	case 178: goto tr69;
+	case 179: goto tr69;
+	case 180: goto tr69;
+	case 181: goto tr69;
+	case 182: goto tr69;
+	case 183: goto tr69;
+	case 184: goto tr69;
+	case 185: goto tr69;
+	case 186: goto tr69;
+	case 187: goto tr69;
+	case 188: goto tr69;
+	case 189: goto tr69;
+	case 190: goto tr69;
+	case 191: goto tr69;
+	case 192: goto tr69;
+	case 193: goto tr69;
+	case 194: goto tr69;
+	case 195: goto tr69;
+	case 196: goto tr69;
+	case 197: goto tr69;
+	case 198: goto tr69;
+	case 199: goto tr69;
+	case 200: goto tr69;
+	case 201: goto tr69;
+	case 202: goto tr69;
+	case 203: goto tr69;
+	case 204: goto tr69;
+	case 205: goto tr69;
+	case 206: goto tr69;
+	case 207: goto tr69;
+	case 208: goto tr69;
+	case 209: goto tr69;
+	case 210: goto tr69;
+	case 316: goto tr372;
+	case 211: goto tr69;
+	case 212: goto tr69;
+	case 213: goto tr69;
+	case 214: goto tr69;
+	case 215: goto tr69;
+	case 216: goto tr69;
+	case 217: goto tr62;
+	case 317: goto tr432;
+	case 218: goto tr62;
+	case 219: goto tr62;
+	case 220: goto tr69;
+	case 318: goto tr372;
+	case 221: goto tr69;
+	case 222: goto tr69;
+	case 223: goto tr69;
+	case 320: goto tr437;
+	case 224: goto tr262;
+	case 225: goto tr262;
+	case 226: goto tr262;
+	case 227: goto tr262;
+	case 228: goto tr262;
+	case 322: goto tr442;
+	case 229: goto tr268;
+	case 230: goto tr268;
+	case 231: goto tr268;
+	case 232: goto tr268;
+	case 233: goto tr268;
+	case 234: goto tr268;
+	case 235: goto tr268;
+	case 236: goto tr268;
+	case 324: goto tr447;
+	case 237: goto tr277;
+	case 238: goto tr277;
+	case 239: goto tr277;
+	case 240: goto tr277;
+	case 241: goto tr277;
+	case 242: goto tr277;
+	case 243: goto tr277;
+	case 244: goto tr277;
+	case 245: goto tr277;
+	case 246: goto tr277;
+	case 247: goto tr277;
+	case 248: goto tr277;
+	case 249: goto tr277;
+	case 250: goto tr277;
+	case 251: goto tr277;
+	case 252: goto tr277;
+	case 253: goto tr277;
+	case 254: goto tr277;
+	case 255: goto tr277;
+	case 256: goto tr277;
+	case 257: goto tr277;
+	case 258: goto tr277;
+	case 259: goto tr277;
+	case 260: goto tr277;
+	case 261: goto tr277;
+	case 262: goto tr277;
+	case 326: goto tr311;
+	case 263: goto tr311;
+	case 327: goto tr456;
+	case 328: goto tr456;
+	case 264: goto tr313;
+	case 329: goto tr457;
+	case 330: goto tr457;
+	case 265: goto tr313;
 	}
 	}
 
 	}
 
-#line 1386 "ext/dtext/dtext.rl"
+#line 1389 "ext/dtext/dtext.rl"
 
   dstack_close(sm);
 

--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -138,6 +138,9 @@ aliased_wiki_link = '[[' nonpipebracket+ >mark_a1 %mark_a2 '|' nonpipebracket+ >
 
 post_link = '{{' noncurly+ >mark_a1 %mark_a2 '}}';
 
+spoilers_open = '[spoiler'i 's'i? ']';
+spoilers_close = '[/spoiler'i 's'i? ']';
+
 post_id = 'post #'i digit+ >mark_a1 %mark_a2;
 forum_post_id = 'forum #'i digit+ >mark_a1 %mark_a2;
 forum_topic_id = 'topic #'i digit+ >mark_a1 %mark_a2;
@@ -531,14 +534,14 @@ inline := |*
     }
   };
 
-  '[spoiler]'i => {
+  spoilers_open => {
     g_debug("inline [spoiler]");
     g_debug("  push <span>");
     dstack_push(sm, &INLINE_SPOILER);
     append(sm, true, "<span class=\"spoiler\">");
   };
 
-  '[/spoiler]'i => {
+  spoilers_close => {
     g_debug("inline [/spoiler]");
     dstack_close_before_block(sm);
 
@@ -933,7 +936,7 @@ main := |*
     append_block(sm, "<blockquote>");
   };
 
-  '[spoiler]'i space* => {
+  spoilers_open space* => {
     g_debug("block [spoiler]");
     g_debug("  push spoiler");
     g_debug("  print <div>");
@@ -942,7 +945,7 @@ main := |*
     append_block(sm, "<div class=\"spoiler\">");
   };
 
-  '[/spoiler]'i => {
+  spoilers_close => {
     g_debug("block [/spoiler]");
     dstack_close_before_block(sm);
     if (dstack_check(sm, BLOCK_SPOILER)) {

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -52,8 +52,16 @@ class DTextTest < Minitest::Test
     assert_parse("<p>this is <span class=\"spoiler\">an inline spoiler</span>.</p>", "this is [spoiler]an inline spoiler[/spoiler].")
   end
 
+  def test_spoilers_inline_plural
+    assert_parse("<p>this is <span class=\"spoiler\">an inline spoiler</span>.</p>", "this is [SPOILERS]an inline spoiler[/SPOILERS].")
+  end
+
   def test_spoilers_block
     assert_parse("<p>this is</p><div class=\"spoiler\"><p>a block spoiler</p></div><p>.</p>", "this is\n\n[spoiler]\na block spoiler\n[/spoiler].")
+  end
+
+  def test_spoilers_block_plural
+    assert_parse("<p>this is</p><div class=\"spoiler\"><p>a block spoiler</p></div><p>.</p>", "this is\n\n[SPOILERS]\na block spoiler\n[/SPOILERS].")
   end
 
   def test_spoilers_with_no_closing_tag_1


### PR DESCRIPTION
Fix the ragel parser to accept both `[spoilers]` and `[spoiler]` for spoiler tags. Reported in http://danbooru.donmai.us/forum_topics/9127?page=142#forum_post_123725.