### PR TITLE
dtext.rl: allow fragment-only urls in named links ("foo":#toc).

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -104,7 +104,7 @@ utf8graph = (0x00..0x7F) & graph
 mention = '@' utf8graph+ >mark_a1 %mark_a2;
 
 url = 'http' 's'? '://' utf8graph+;
-internal_url = '/' utf8graph+;
+internal_url = [/#] utf8graph+;
 basic_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':' (url | internal_url) >mark_b1 %mark_b2;
 bracketed_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':[' (url | internal_url) >mark_b1 %mark_b2 :>> ']';
 

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -197,6 +197,11 @@ class DTextTest < Minitest::Test
     assert_parse('<p>[<a class="dtext-link dtext-external-link" href="http://test.com/(parentheses)">test</a>]</p>', '["test":[http://test.com/(parentheses)]]')
   end
 
+  def test_fragment_only_urls
+    assert_parse('<p><a class="dtext-link dtext-external-link" href="#toc">test</a></p>', '"test":#toc')
+    assert_parse('<p><a class="dtext-link dtext-external-link" href="#toc">test</a></p>', '"test":[#toc]')
+  end
+
   def test_lists_1
     assert_parse('<ul><li>a</li></ul>', '* a')
   end


### PR DESCRIPTION
Fixes #13.