### PR TITLE
Fix #18: Add syntax for delimited links: <http://www.example.com>

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -102,8 +102,10 @@ utf8graph = (0x00..0x7F) & graph
 
 
 mention = '@' utf8graph+ >mark_a1 %mark_a2;
+delimited_mention = '<' mention :>> '>';
 
 url = 'http' 's'? '://' utf8graph+;
+delimited_url = '<' url :>> '>';
 internal_url = [/#] utf8graph+;
 basic_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':' (url | internal_url) >mark_b1 %mark_b2;
 bracketed_textile_link = '"' nonquote+ >mark_a1 '"' >mark_a2 ':[' (url | internal_url) >mark_b1 %mark_b2 :>> ']';
@@ -354,6 +356,14 @@ inline := |*
     }
   };
 
+  delimited_url => {
+    append(sm, true, "<a href=\"");
+    append_segment_html_escaped(sm, sm->ts + 1, sm->te - 2);
+    append(sm, true, "\">");
+    append_segment_html_escaped(sm, sm->ts + 1, sm->te - 2);
+    append(sm, true, "</a>");
+  };
+
   # probably a tag. examples include @.@ and @_@
   '@' graph '@' => {
     append_segment_html_escaped(sm, sm->ts, sm->te - 1);
@@ -384,6 +394,17 @@ inline := |*
       if (sm->b) {
         append_c_html_escaped(sm, fc);
       }
+    }
+  };
+
+  delimited_mention => {
+    if (sm->f_mentions) {
+      append(sm, true, "<a rel=\"nofollow\" href=\"/users?name=");
+      append_segment_uri_escaped(sm, sm->a1, sm->a2 - 1);
+      append(sm, true, "\">");
+      append_c(sm, '@');
+      append_segment_html_escaped(sm, sm->a1, sm->a2 - 1);
+      append(sm, true, "</a>");
     }
   };
 

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -302,10 +302,22 @@ class DTextTest < Minitest::Test
     assert_parse('<p>Should not parse 葉月@葉月</p>', "Should not parse 葉月@葉月")
   end
 
+  def test_delimited_mentions
+    dtext = '(blah <@evazion>).'
+    html = '<p>(blah <a rel="nofollow" href="/users?name=evazion">@evazion</a>).</p>'
+    assert_parse(html, dtext)
+  end
+
   def test_utf8_links
     assert_parse('<p><a class="dtext-link dtext-external-link" href="/posts?tags=approver:葉月">7893</a></p>', '"7893":/posts?tags=approver:葉月')
     assert_parse('<p><a class="dtext-link dtext-external-link" href="/posts?tags=approver:葉月">7893</a></p>', '"7893":[/posts?tags=approver:葉月]')
     assert_parse('<p><a href="http://danbooru.donmai.us/posts?tags=approver:葉月">http://danbooru.donmai.us/posts?tags=approver:葉月</a></p>', 'http://danbooru.donmai.us/posts?tags=approver:葉月')
+  end
+
+  def test_delimited_links
+    dtext = '(blah <https://en.wikipedia.org/wiki/Orange_(fruit)>).'
+    html = '<p>(blah <a href="https://en.wikipedia.org/wiki/Orange_(fruit)">https://en.wikipedia.org/wiki/Orange_(fruit)</a>).</p>'
+    assert_parse(html, dtext)
   end
 
   def test_nodtext


### PR DESCRIPTION
Fixes #18. Adds the following syntax:

* `<http://www.example.com>`
* `<@mention>`