### PR TITLE
Fix #17: ignore trailing unicode punctuation when parsing links.

### DIFF
--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -202,6 +202,20 @@ class DTextTest < Minitest::Test
     assert_parse('<p><a class="dtext-link dtext-external-link" href="#toc">test</a></p>', '"test":[#toc]')
   end
 
+  def test_auto_url_boundaries
+    assert_parse('<p>a （<a href="http://test.com">http://test.com</a>） b</p>', 'a （http://test.com） b')
+    assert_parse('<p>a 〜<a href="http://test.com">http://test.com</a>〜 b</p>', 'a 〜http://test.com〜 b')
+    assert_parse('<p>a <a href="http://test.com">http://test.com</a>　 b</p>', 'a http://test.com　 b')
+  end
+
+  def test_old_style_link_boundaries
+    assert_parse('<p>a 「<a class="dtext-link dtext-external-link" href="http://test.com">title</a>」 b</p>', 'a 「"title":http://test.com」 b')
+  end
+
+  def test_new_style_link_boundaries
+    assert_parse('<p>a 「<a class="dtext-link dtext-external-link" href="http://test.com">title</a>」 b</p>', 'a 「"title":[http://test.com]」 b')
+  end
+
   def test_lists_1
     assert_parse('<ul><li>a</li></ul>', '* a')
   end
@@ -300,6 +314,10 @@ class DTextTest < Minitest::Test
     assert_parse('<p><a rel="nofollow" href="/users?name=葉月">@葉月</a></p>', "@葉月")
     assert_parse('<p>Hello <a rel="nofollow" href="/users?name=葉月">@葉月</a> and <a rel="nofollow" href="/users?name=Alice">@Alice</a></p>', "Hello @葉月 and @Alice")
     assert_parse('<p>Should not parse 葉月@葉月</p>', "Should not parse 葉月@葉月")
+  end
+
+  def test_mention_boundaries
+    assert_parse('<p>「hi <a rel="nofollow" href="/users?name=葉月">@葉月</a>」</p>', "「hi @葉月」")
   end
 
   def test_utf8_links


### PR DESCRIPTION
Fixes #17. Ignores these trailing Unicode punctuation characters when parsing links:

* http://www.fileformat.info/info/unicode/category/Pe/list.htm
* http://www.fileformat.info/info/unicode/block/cjk_symbols_and_punctuation/list.htm

Doing this required some refactoring. Previously, if a byte was a boundary character, then `is_boundary_c` would return true, signaling we should skip over that byte. But now we need to skip multibyte Unicode characters, not just a single byte. Therefore we instead have `find_boundary_c` return a pointer to the character before the boundary character to be skipped.