### PR TITLE
Add note #1234 syntax.

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -117,6 +117,7 @@ spoilers_open = '[spoiler'i 's'i? ']';
 spoilers_close = '[/spoiler'i 's'i? ']';
 
 post_id = 'post #'i digit+ >mark_a1 %mark_a2;
+note_id = 'note #'i digit+ >mark_a1 %mark_a2;
 forum_post_id = 'forum #'i digit+ >mark_a1 %mark_a2;
 forum_topic_id = 'topic #'i digit+ >mark_a1 %mark_a2;
 forum_topic_paged_id = 'topic #'i digit+ >mark_a1 %mark_a2 '/p' digit+ >mark_b1 %mark_b2;
@@ -142,6 +143,15 @@ inline := |*
     append_segment(sm, true, sm->a1, sm->a2 - 1);
     append(sm, true, "\">");
     append(sm, false, "post #");
+    append_segment(sm, false, sm->a1, sm->a2 - 1);
+    append(sm, true, "</a>");
+  };
+
+  note_id => {
+    append(sm, true, "<a class=\"dtext-link dtext-id-link dtext-note-id-link\" href=\"/notes/");
+    append_segment(sm, true, sm->a1, sm->a2 - 1);
+    append(sm, true, "\">");
+    append(sm, false, "note #");
     append_segment(sm, false, sm->a1, sm->a2 - 1);
     append(sm, true, "</a>");
   };

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -252,6 +252,10 @@ class DTextTest < Minitest::Test
     assert_parse("<p>Tags <strong>(<a class=\"dtext-link dtext-wiki-link\" href=\"/wiki_pages/show_or_new?title=howto%3Atag\">Tagging Guidelines</a> | <a class=\"dtext-link dtext-wiki-link\" href=\"/wiki_pages/show_or_new?title=howto%3Atag_checklist\">Tag Checklist</a> | <a class=\"dtext-link dtext-wiki-link\" href=\"/wiki_pages/show_or_new?title=tag_groups\">Tag Groups</a>)</strong></p>", "Tags [b]([[howto:tag|Tagging Guidelines]] | [[howto:tag_checklist|Tag Checklist]] | [[Tag Groups]])[/b]")
   end
 
+  def text_note_id_link
+    assert_parse('<p><a class="dtext-link dtext-id-link dtext-note-id-link" href="/notes/1234">note #1234</a></p>', "note #1234")
+  end
+
   def test_table
     assert_parse("<table class=\"striped\"><thead><tr><th>header</th></tr></thead><tbody><tr><td><a class=\"dtext-link dtext-id-link dtext-post-id-link\" href=\"/posts/100\">post #100</a></td></tr></tbody></table>", "[table][thead][tr][th]header[/th][/tr][/thead][tbody][tr][td]post #100[/td][/tr][/tbody][/table]")
   end


### PR DESCRIPTION
Adds `note #1234` syntax. This is to support https://github.com/r888888888/danbooru/issues/3205.