### PR TITLE
Fix #22: Issues with @ symbol processing.

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -375,8 +375,7 @@ inline := |*
     if (!sm->f_mentions || (sm->a1 > sm->pb && sm->a1 - 1 > sm->pb && sm->a1[-2] != ' ' && sm->a1[-2] != '\r' && sm->a1[-2] != '\n')) {
       // handle emails
       append_c(sm, '@');
-      append_segment_html_escaped(sm, sm->a1, sm->a2 - 1);
-
+      fexec sm->a1;
     } else {
       const char* match_end = sm->a2 - 1;
       const char* name_start = sm->a1;

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -31,6 +31,10 @@ class DTextTest < Minitest::Test
     assert_equal('<p>hi @bob</p>', DTextRagel.parse("hi @bob", :disable_mentions => true))
   end
 
+  def test_nested_nonmention
+    assert_parse('<p>foo <strong>idolm@ster</strong> bar</p>', 'foo [b]idolm@ster[/b] bar')
+  end
+
   def test_sanitize_heart
     assert_parse('<p>&lt;3</p>', "<3")
   end


### PR DESCRIPTION
Fixes #22. Fixes parsing of `foo [b]idolm@ster[/b] bar`. The problem was that the parser, after matching the `@`, would swallow up `ster[/b]` and append it literally. This makes it instead resume parsing as usual immediately after the `@`.