### PR TITLE
Fix #28: Block-level [tn] tags are never closed.

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -361,14 +361,10 @@ inline := |*
   '[/tn]'i => {
     dstack_close_before_block(sm);
 
-    if (dstack_check(sm, BLOCK_TN)) {
-      dstack_pop(sm);
+    if (dstack_check(sm, INLINE_TN)) {
+      dstack_close_inline(sm, INLINE_TN, "</span>");
+    } else if (dstack_close_block(sm, BLOCK_TN, "</p>")) {
       fret;
-    } else if (dstack_check(sm, INLINE_TN)) {
-      dstack_pop(sm);
-      append(sm, true, "</span>");
-    } else {
-      append_block(sm, "[/tn]");
     }
   };
 

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -129,6 +129,14 @@ class DTextTest < Minitest::Test
     assert_parse("<p>h1#blah-&quot;blah. header</p>", "h1#blah-\"blah. header")
   end
 
+  def test_inline_tn
+    assert_parse('<p>foo <span class="tn">bar</span></p>', "foo [tn]bar[/tn]")
+  end
+
+  def test_block_tn
+    assert_parse('<p class="tn">bar</p>', "[tn]bar[/tn]")
+  end
+
   def test_quote_blocks
     assert_parse('<blockquote><p>test</p></blockquote>', "[quote]\ntest\n[/quote]")
   end
@@ -335,7 +343,7 @@ class DTextTest < Minitest::Test
   def test_mention_boundaries
     assert_parse('<p>「hi <a rel="nofollow" href="/users?name=葉月">@葉月</a>」</p>', "「hi @葉月」")
   end
-  
+
   def test_delimited_mentions
     dtext = '(blah <@evazion>).'
     html = '<p>(blah <a rel="nofollow" href="/users?name=evazion">@evazion</a>).</p>'


### PR DESCRIPTION
Fixes #28. The bug was just that for `BLOCK_TN` elements we called `dstack_pop`, but we didn't call `append` to append the `</p>`. Call `dstack_close_block(sm, BLOCK_TN, "</p>")` to close the block properly.