### PR TITLE
Fix #32: Not all external links get the dtext-external-link class.

### DIFF
--- a/ext/dtext/dtext.rl
+++ b/ext/dtext/dtext.rl
@@ -245,11 +245,7 @@ inline := |*
     const char* url_start = sm->ts;
     const char* url_end = find_boundary_c(match_end);
 
-    append(sm, true, "<a href=\"");
-    append_segment_html_escaped(sm, url_start, url_end);
-    append(sm, true, "\">");
-    append_segment_html_escaped(sm, url_start, url_end);
-    append(sm, true, "</a>");
+    append_url(sm, url_start, url_end, url_start, url_end);
 
     if (url_end < match_end) {
       append_segment_html_escaped(sm, url_end + 1, match_end);
@@ -257,11 +253,7 @@ inline := |*
   };
 
   delimited_url => {
-    append(sm, true, "<a href=\"");
-    append_segment_html_escaped(sm, sm->ts + 1, sm->te - 2);
-    append(sm, true, "\">");
-    append_segment_html_escaped(sm, sm->ts + 1, sm->te - 2);
-    append(sm, true, "</a>");
+    append_url(sm, sm->ts + 1, sm->te - 2, sm->ts + 1, sm->te - 2);
   };
 
   # probably a tag. examples include @.@ and @_@
@@ -921,6 +913,14 @@ static inline void append_link(StateMachine * sm, const char * title, const char
   append(sm, true, "\">");
   append(sm, false, title);
   append_segment_html_escaped(sm, sm->a1, sm->a2 - 1);
+  append(sm, true, "</a>");
+}
+
+static inline void append_url(StateMachine * sm, const char * url_start, const char * url_end, const char * title_start, const char * title_end) {
+  append(sm, true, "<a class=\"dtext-link dtext-external-link\" href=\"");
+  append_segment_html_escaped(sm, url_start, url_end);
+  append(sm, true, "\">");
+  append_segment_html_escaped(sm, title_start, title_end);
   append(sm, true, "</a>");
 }
 

--- a/test/dtext_test.rb
+++ b/test/dtext_test.rb
@@ -164,27 +164,27 @@ class DTextTest < Minitest::Test
   end
 
   def test_urls
-    assert_parse('<p>a <a href="http://test.com">http://test.com</a> b</p>', 'a http://test.com b')
+    assert_parse('<p>a <a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a> b</p>', 'a http://test.com b')
   end
 
   def test_urls_with_newline
-    assert_parse('<p><a href="http://test.com">http://test.com</a><br>b</p>', "http://test.com\nb")
+    assert_parse('<p><a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a><br>b</p>', "http://test.com\nb")
   end
 
   def test_urls_with_paths
-    assert_parse('<p>a <a href="http://test.com/~bob/image.jpg">http://test.com/~bob/image.jpg</a> b</p>', 'a http://test.com/~bob/image.jpg b')
+    assert_parse('<p>a <a class="dtext-link dtext-external-link" href="http://test.com/~bob/image.jpg">http://test.com/~bob/image.jpg</a> b</p>', 'a http://test.com/~bob/image.jpg b')
   end
 
   def test_urls_with_fragment
-    assert_parse('<p>a <a href="http://test.com/home.html#toc">http://test.com/home.html#toc</a> b</p>', 'a http://test.com/home.html#toc b')
+    assert_parse('<p>a <a class="dtext-link dtext-external-link" href="http://test.com/home.html#toc">http://test.com/home.html#toc</a> b</p>', 'a http://test.com/home.html#toc b')
   end
 
   def test_auto_urls
-    assert_parse('<p>a <a href="http://test.com">http://test.com</a>. b</p>', 'a http://test.com. b')
+    assert_parse('<p>a <a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a>. b</p>', 'a http://test.com. b')
   end
 
   def test_auto_urls_in_parentheses
-    assert_parse('<p>a (<a href="http://test.com">http://test.com</a>) b</p>', 'a (http://test.com) b')
+    assert_parse('<p>a (<a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a>) b</p>', 'a (http://test.com) b')
   end
 
   def test_old_style_links
@@ -219,9 +219,9 @@ class DTextTest < Minitest::Test
   end
 
   def test_auto_url_boundaries
-    assert_parse('<p>a （<a href="http://test.com">http://test.com</a>） b</p>', 'a （http://test.com） b')
-    assert_parse('<p>a 〜<a href="http://test.com">http://test.com</a>〜 b</p>', 'a 〜http://test.com〜 b')
-    assert_parse('<p>a <a href="http://test.com">http://test.com</a>　 b</p>', 'a http://test.com　 b')
+    assert_parse('<p>a （<a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a>） b</p>', 'a （http://test.com） b')
+    assert_parse('<p>a 〜<a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a>〜 b</p>', 'a 〜http://test.com〜 b')
+    assert_parse('<p>a <a class="dtext-link dtext-external-link" href="http://test.com">http://test.com</a>　 b</p>', 'a http://test.com　 b')
   end
 
   def test_old_style_link_boundaries
@@ -353,12 +353,12 @@ class DTextTest < Minitest::Test
   def test_utf8_links
     assert_parse('<p><a class="dtext-link dtext-external-link" href="/posts?tags=approver:葉月">7893</a></p>', '"7893":/posts?tags=approver:葉月')
     assert_parse('<p><a class="dtext-link dtext-external-link" href="/posts?tags=approver:葉月">7893</a></p>', '"7893":[/posts?tags=approver:葉月]')
-    assert_parse('<p><a href="http://danbooru.donmai.us/posts?tags=approver:葉月">http://danbooru.donmai.us/posts?tags=approver:葉月</a></p>', 'http://danbooru.donmai.us/posts?tags=approver:葉月')
+    assert_parse('<p><a class="dtext-link dtext-external-link" href="http://danbooru.donmai.us/posts?tags=approver:葉月">http://danbooru.donmai.us/posts?tags=approver:葉月</a></p>', 'http://danbooru.donmai.us/posts?tags=approver:葉月')
   end
 
   def test_delimited_links
     dtext = '(blah <https://en.wikipedia.org/wiki/Orange_(fruit)>).'
-    html = '<p>(blah <a href="https://en.wikipedia.org/wiki/Orange_(fruit)">https://en.wikipedia.org/wiki/Orange_(fruit)</a>).</p>'
+    html = '<p>(blah <a class="dtext-link dtext-external-link" href="https://en.wikipedia.org/wiki/Orange_(fruit)">https://en.wikipedia.org/wiki/Orange_(fruit)</a>).</p>'
     assert_parse(html, dtext)
   end
 


### PR DESCRIPTION
Fixes #32.